### PR TITLE
Add readme with Travis status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+[![Build Status](https://travis-ci.org/altMITgcm/MITgcm66h.svg?branch=master)](https://travis-ci.org/altMITgcm/MITgcm66h)
+
+# MITgcm66h
+M.I.T general circulation model as of checkpoint66h with author emails


### PR DESCRIPTION
The current status of the master branch (passing or failing automated tests) is indicated by a badge at the top of the readme.