### PR TITLE
Ignore all build and run subdirectories; closes #12.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ _*
 core
 # CVS default ignores end
 notes
+build/
+run/


### PR DESCRIPTION
I just appended "run/" and "build/" to .gitignore.

I don't see any reason not to ignore all "build" and "run" subdirectories and their contents, hence the suggested change.  The trailing slash ensures that "*/build/*" will be ignored, but "*/now_build_something.sh" will not.