### PR TITLE
New Package NF90IO: NetCDF writing for diagnostics package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ _*
 core
 # CVS default ignores end
 notes
+build/
+run/

--- a/model/inc/PARAMS.h
+++ b/model/inc/PARAMS.h
@@ -1031,6 +1031,7 @@ C Logical flags for selecting packages
       LOGICAL useREGRID
       LOGICAL useLayers
       LOGICAL useMNC
+      LOGICAL useNF90IO
       LOGICAL useRunClock
       LOGICAL useEMBED_FILES
       LOGICAL useMYPACKAGE
@@ -1046,7 +1047,7 @@ C Logical flags for selecting packages
      &        useStreamIce, useICEFRONT, useThSIce, useLand,
      &        useATM2D, useAIM, useAtm_Phys, useFizhi, useGridAlt,
      &        useDiagnostics, useREGRID, useLayers, useMNC,
-     &        useRunClock, useEMBED_FILES,
+     &        useRunClock, useEMBED_FILES, useNF90IO,
      &        useMYPACKAGE
 
 CEH3 ;;; Local Variables: ***

--- a/model/src/packages_boot.F
+++ b/model/src/packages_boot.F
@@ -94,6 +94,7 @@ C     data.pkg namelists
      &          useREGRID,
      &          useLayers,
      &          useMNC,
+     &          useNF90IO,
      &          useRunClock,
      &          useEMBED_FILES,
      &          useMYPACKAGE
@@ -158,6 +159,7 @@ c     useGAD          =.FALSE.
       useREGRID       =.FALSE.
       useLayers       =.FALSE.
       useMNC          =.FALSE.
+      useNF90IO       =.FALSE.
       useRunClock     =.FALSE.
       useEMBED_FILES  =.FALSE.
       useMYPACKAGE    =.FALSE.
@@ -393,6 +395,9 @@ C----- pkgs with a standard "usePKG" On/Off switch in "data.pkg":
 #endif
 #ifdef ALLOW_MNC
       CALL PACKAGES_PRINT_MSG( useMNC,        'MNC',         ' ' )
+#endif
+#ifdef ALLOW_NF90IO
+      CALL PACKAGES_PRINT_MSG( useNF90IO,     'NF90IO',      ' ' )
 #endif
 #ifdef ALLOW_RUNCLOCK
       CALL PACKAGES_PRINT_MSG( useRunClock,   'RunClock',    ' ' )

--- a/pkg/diagnostics/DIAGNOSTICS.h
+++ b/pkg/diagnostics/DIAGNOSTICS.h
@@ -119,7 +119,7 @@ c     INTEGER misValInt(numLists)
       CHARACTER*8  flds  (numperList,numLists)
       CHARACTER*80 fnames(numLists)
       CHARACTER*8  fflags(numLists)
-      LOGICAL diag_mdsio, diag_mnc, useMissingValue
+      LOGICAL diag_mdsio, diag_mnc, diag_nf90io, useMissingValue
 
       COMMON / DIAG_SELECT_R /
      &     freq, phase, averageFreq, averagePhase,
@@ -132,7 +132,7 @@ c    &   , misValInt
       COMMON / DIAG_SELECT_C /
      &     flds, fnames, fflags
       COMMON / DIAG_SELECT_L /
-     &     diag_mdsio, diag_mnc, useMissingValue
+     &     diag_mdsio, diag_mnc, diag_nf90io, useMissingValue
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 

--- a/pkg/diagnostics/diagnostics_nf90io_out.F
+++ b/pkg/diagnostics/diagnostics_nf90io_out.F
@@ -1,0 +1,323 @@
+C $Header$
+C $Name$
+
+#include "DIAG_OPTIONS.h"
+
+C--   File diagnostics_nf90io_out.F: Routines to write NF90IO diagnostics output
+C--    Contents:
+C--    o DIAGNOSTICS_NF90IO_OUT
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+CBOP 0
+C     !ROUTINE: DIAGNOSTICS_NF90IO_OUT
+
+C     !INTERFACE:
+      SUBROUTINE DIAGNOSTICS_NF90IO_OUT(
+     I     NrMax, nLevOutp, listId, ndId,
+     I     qtmp, incrementRec, timeRec,
+     I     misValLoc, myTime, myIter, myThid )
+
+C     !DESCRIPTION:
+C     write diagnostics fields to MNC file.
+
+C     !USES:
+#ifdef ALLOW_NF90IO
+      use netcdf
+#endif
+
+      IMPLICIT NONE
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+#include "GRID.h"
+#include "DIAGNOSTICS_SIZE.h"
+#include "DIAGNOSTICS.h"
+#ifdef ALLOW_NF90IO
+#include "mpif.h"
+C #include "NF90IO.h"
+#endif
+
+C     !INPUT PARAMETERS:
+C     NrMax           :: 3rd dimension of output-field array to write
+C     nLevOutp        :: number of levels to write in output file
+C     listId          :: Diagnostics list number being written
+C     ndId            :: diagnostics Id number (in available diagnostics list)
+C     qtmp            :: output-field array to write
+C     incrementRec    :: logical to increment record number or not
+C     timeRec         :: time of start and end of averaging.  
+C     misValLoc       :: local Missing Value
+C     myTime          :: current time of simulation (s)
+C     myIter          :: current iteration number
+C     myThid          :: my Thread Id number
+      INTEGER NrMax
+      INTEGER nLevOutp
+      INTEGER listId, ndId
+      _RL     qtmp(1-OLx:sNx+OLx,1-OLy:sNy+OLy,NrMax,nSx,nSy)
+      _RL     misValLoc
+      _RL     myTime
+      INTEGER myIter, myThid
+      _RL timeRec(2)
+      LOGICAL incrementRec
+CEOP
+
+#ifdef ALLOW_NF90IO
+C     !FUNCTIONS:
+      INTEGER ILNBLNK
+      EXTERNAL ILNBLNK
+
+C     !LOCAL VARIABLES:
+C     i,j,k :: loop indices
+C     bi,bj :: tile indices
+      INTEGER i, j, k
+      INTEGER bi, bj
+
+c     CHARACTER*(MAX_LEN_MBUF) msgBuf
+c     INTEGER ll, llMx, jj, jjMx
+      INTEGER ii, klev
+      INTEGER CW_DIMS, NLEN
+      PARAMETER ( CW_DIMS = 10 )
+      PARAMETER ( NLEN    = 80 )
+      INTEGER dim(CW_DIMS), ib(CW_DIMS), ie(CW_DIMS)
+      CHARACTER*(NLEN) dn(CW_DIMS)
+      CHARACTER*(NLEN) d_cw_name
+      CHARACTER*(MAX_LEN_FNAM) fname
+c     CHARACTER*(NLEN) dn_blnk
+      LOGICAL useMisValForThisDiag
+      REAL*8  misval_r8(2)
+      REAL*4  misval_r4(2)
+      INTEGER ncid, varid, rec_dimid, i_dimid, j_dimid, k_dimid, err
+      INTEGER iLen
+      INTEGER dimids(4)
+      INTEGER iRec
+      INTEGER misval_int(2)
+      LOGICAL lexist
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+c     IF (useMNC .AND. diag_mnc) THEN
+
+C        NF90IO: don't think we need this.  
+C        _BEGIN_MASTER( myThid )
+
+C     get the filename
+      iLen = ILNBLNK(fnames(listId))
+      WRITE( fname, '(A,A3)' ) fnames(listId)(1:iLen), '.nc'
+      iLen = iLen+3
+      print *,fname(1:iLen)
+
+C     TODO:
+C      wjay the heck to I do with iRec?
+
+C     Check if fname exists.  This is all we will do - we are big kids.  If the file
+C     exists and its different than this version, then we should have erased it.
+C     Of course I'm stupid and often forget to erase files.  
+      INQUIRE(file=fname(1:iLen),exist=lexist)
+      IF (.NOT.lexist) THEN
+         CALL NF90IO_INIT_FILE(fname(1:iLen), myThid)
+C        This defines most of the dimensions and all the grid variables.
+C        Basic init doesn't add timestart and timeend variables. Lets 
+C        do that here.         
+         err = nf90_open(fname(1:iLen), IOR(nf90_write, nf90_mpiio),
+     $        ncid,
+     $        comm=MPI_COMM_WORLD,   info=MPI_INFO_NULL)
+         CALL nf90ERR(err, "Open diagnostic nc file to write",myThid)
+C        put in redef mode...
+         err = nf90_redef(ncid)
+         CALL nf90ERR(err, "Redef mode failed!",myThid)
+         err = nf90_inq_dimid(ncid, 'record', rec_dimid)
+         CALL nf90ERR(err, "inq record_dimid",myThid)
+         err = nf90_def_var(ncid, "timestart", NF90_DOUBLE, (/ rec_dimid
+     $        /),varid)
+         CALL nf90ERR(err, "defining timestart variable",myThid)
+         err = nf90_def_var(ncid, "timeend", NF90_DOUBLE, (/ rec_dimid
+     $        /),varid)
+         CALL nf90ERR(err, "defining timeend variable",myThid)
+         err = nf90_enddef(ncid)
+         err = nf90_close(ncid)
+         CALL nf90ERR(err, "closing after initialization",myThid)
+      ENDIF
+
+C OK, open the file and get the netcdf id
+      err = nf90_open(fname(1:iLen), IOR(nf90_write, nf90_mpiio),
+     $     ncid,
+     $     comm=MPI_COMM_WORLD,   info=MPI_INFO_NULL)
+      CALL nf90ERR(err, "Open diagnostic nc file to write",myThid)
+C     get the variable id
+      print *,"getting varid"
+      print *,cdiag(ndId)
+      err = nf90_inq_varid(ncid, cdiag(ndId), varid)
+      IF (.NOT.(err.EQ.nf90_NoErr)) THEN
+         print *,"Defining varid"
+         print *,cdiag(ndId)
+C       we need to define this variable
+C       put in redef mode...
+        err = nf90_redef(ncid)
+C       we need to initialize this variable
+        err = nf90_inq_dimid(ncid, 'record', rec_dimid)
+        CALL nf90ERR(err, "inq record_dimid",myThid)
+C       gdiag will tell us what the other two or three dimensions are
+C       so here we get i_dimid and j_dimid with the proper dimensions
+        IF (gdiag(ndId)(2:2) .EQ. 'M') THEN
+           err = nf90_inq_dimid(ncid, 'i', i_dimid)
+           CALL nf90ERR(err, "inq i_dimid",myThid)
+           err = nf90_inq_dimid(ncid, 'j', j_dimid)
+           CALL nf90ERR(err, "inq i_dimid",myThid)
+        ELSEIF (gdiag(ndId)(2:2) .EQ. 'U') THEN
+           err = nf90_inq_dimid(ncid, 'i_g', i_dimid)
+           CALL nf90ERR(err, "inq i_dimid",myThid)
+           err = nf90_inq_dimid(ncid, 'j', j_dimid)
+           CALL nf90ERR(err, "inq i_dimid",myThid)
+        ELSEIF (gdiag(ndId)(2:2) .EQ. 'V') THEN
+           err = nf90_inq_dimid(ncid, 'i', i_dimid)
+           CALL nf90ERR(err, "inq i_dimid",myThid)
+           err = nf90_inq_dimid(ncid, 'j_g', j_dimid)
+           CALL nf90ERR(err, "inq i_dimid",myThid)
+         ELSEIF (gdiag(ndId)(2:2) .EQ. 'Z') THEN
+           err = nf90_inq_dimid(ncid, 'i_g', i_dimid)
+           CALL nf90ERR(err, "inq i_dimid",myThid)
+           err = nf90_inq_dimid(ncid, 'j_g', j_dimid)
+           CALL nf90ERR(err, "inq i_dimid",myThid)
+         ENDIF
+C        do the same for k_dimid (if necessary) 
+         IF (nLevOutp.EQ.Nr) THEN
+            err = nf90_inq_dimid(ncid, 'k', k_dimid)
+            CALL nf90ERR(err, "inq k_dimid",myThid)
+            IF ( (gdiag(ndId)(10:10) .EQ. 'R')
+     &           .AND. (gdiag(ndId)(9:9) .EQ. 'M') ) THEN
+               err = nf90_inq_dimid(ncid, 'k', k_dimid)
+               CALL nf90ERR(err, "inq k_dimid",myThid)
+            ENDIF
+            IF ( (gdiag(ndId)(10:10) .EQ. 'R')
+     &           .AND. (gdiag(ndId)(9:9) .EQ. 'L') ) THEN
+               err = nf90_inq_dimid(ncid, 'k_l', k_dimid)
+               CALL nf90ERR(err, "inq k_dimid",myThid)
+            ENDIF
+            IF ( (gdiag(ndId)(10:10) .EQ. 'R')
+     &           .AND. (gdiag(ndId)(9:9) .EQ. 'U') ) THEN
+               err = nf90_inq_dimid(ncid, 'k_u', k_dimid)
+               CALL nf90ERR(err, "inq k_dimid",myThid)
+            ENDIF
+
+            dimids =  (/  i_dimid, j_dimid, k_dimid, rec_dimid /)
+            err = nf90_def_var(ncid, cdiag(ndId), NF90_DOUBLE, dimids,
+     $           varid)
+         ELSEIF (nLevOutp.EQ.1) THEN
+C           Define the one-level variable
+            dimids(1:3) =  (/  i_dimid, j_dimid, rec_dimid /)
+            err = nf90_def_var(ncid, cdiag(ndId), NF90_DOUBLE,
+     $           dimids(1:3), varid)            
+         ELSE
+C           This is a multi-level diagnostic and we need to define a new
+C           dimension k_level.
+            err = nf90_inq_dimid(ncid, 'k_level', k_dimid)
+            IF (.NOT.(err.EQ.nf90_NoErr)) THEN
+C             we need to define k_level
+               err = nf90_def_dim(ncid, "k_level", nLevOutp,
+     $              k_dimid)
+               CALL nf90ERR(err,"Adding k_level dim",myThid)
+               err = nf90_def_var(ncid, "k_level", NF90_INT, (/ k_dimid
+     $              /),varid)
+               CALL nf90ERR(err,"Adding k_level variable",myThid)
+               err = nf90_put_att(ncid, varid,
+     $              "standard_name", 
+     $              "z_grid_index")
+               err = nf90_put_att(ncid, varid, 
+     $              "long_name",
+     $              "z-dimension of the level grid")
+C              Drop out of def mode to fill the values in here
+               err = nf90_enddef(ncid)
+               err = nf90_var_par_access(ncid, varid, nf90_collective)
+               CALL nf90ERR(err, "Setting k variable to par access"
+     $              ,myThid)
+               err = nf90_put_var(ncid, varid, levs(1:nLevOutp, listId),
+     $              start = (/ 1 /) , count = (/ nLevOutp /) )
+               CALL nf90ERR(err, "putting data in  k_level variable"
+     $              ,myThid)
+               err = nf90_redef(ncid)
+               CALL nf90ERR(err, "Put netcdf file back in redef"
+     $              ,myThid)
+            ENDIF
+C           Done if we need to define k_level
+            dimids =  (/  i_dimid, j_dimid, k_dimid, rec_dimid /)
+            err = nf90_def_var(ncid, cdiag(ndId), NF90_DOUBLE, dimids,
+     $           varid)
+         ENDIF
+         CALL nf90ERR(err, "Adding diagsnostic variable",myThid)
+C        add attributes to the newy defined variable
+         err = nf90_put_att(ncid, varid,
+     $        "description", 
+     $        tdiag(ndId))
+         CALL nf90ERR(err, "Adding attribute diagnostic variable"
+     $        ,myThid)
+         err = nf90_put_att(ncid, varid,
+     $        "units", 
+     $        udiag(ndId))
+         CALL nf90ERR(err, "Adding attribute diagnostic variable"
+     $        ,myThid)
+C        no standard name?  Booo
+C        end definition mode...
+         err = nf90_enddef(ncid)
+      ENDIF
+C     Done init variable.  varid should be set to receive!
+
+C TODO: the mnc routines had a bunch of stuff setting the missing value in here.    
+C     Need to figure out what record number we are on and increment if we need to
+      err = nf90_inq_dimid(ncid, "record", rec_dimid)
+      err = nf90_inquire_dimension(ncid, rec_dimid, len=iRec)
+      CALL nf90ERR(err, "Getting length of unlimited dimension",myThid)
+      IF (incrementRec) THEN
+        iRec = iRec+1
+        err = nf90_inq_varid(ncid, "record", varid)
+        CALL nf90ERR(err, "Get the record varid",myThid)
+        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90_put_var(ncid, varid, (/ iRec /), start = (/ iRec /),
+     $       count = (/ 1 /) )
+        CALL nf90ERR(err, "Write iRec to the record variable",myThid)
+C       TIME: We should add TIMESTART and TIMEEND so that we can spec avg interval
+        err = nf90_inq_varid(ncid, "time", varid)
+        CALL nf90ERR(err, "Get the time varid",myThid)
+        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90_put_var(ncid, varid, (/ myTime /), start = (/ iRec /)
+     $       ,count = (/ 1 /) )
+        CALL nf90ERR(err, "Write time variable",myThid)
+
+        err = nf90_inq_varid(ncid, "timestart", varid)
+        CALL nf90ERR(err, "Get the timestart varid",myThid)
+        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90_put_var(ncid, varid, (/ timeRec(1) /), start = (/
+     $       iRec /),count = (/ 1 /) )
+        CALL nf90ERR(err, "Write timestart variable",myThid)
+        err = nf90_inq_varid(ncid, "timeend", varid)
+        CALL nf90ERR(err, "Get the timeend varid",myThid)
+        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90_put_var(ncid, varid, (/ timeRec(2) /), start = (/
+     $       iRec /),count = (/ 1 /) )
+        CALL nf90ERR(err, "Write timeend variable",myThid)
+C       ITERATION
+        err = nf90_inq_varid(ncid, "iter", varid)
+        CALL nf90ERR(err, "Get the time varid",myThid)
+        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90_put_var(ncid, varid, (/ myIter /), start = (/ iRec /)
+     $       ,count = (/ 1 /) )
+        CALL nf90ERR(err, "Write iter variable",myThid)
+      ENDIF
+
+C     Write the data
+      IF (nLevOutp.EQ.1) THEN
+         CALL NF90IO_FILL_3D(ncid, cdiag(ndId), qtmp(:,:,1,:,:), iRec,
+     $        myThid)
+      ELSEIF (nLevOutp.LT.Nr) THEN
+         CALL NF90IO_FILL_4DNlev(ncid, cdiag(ndId), nLevOutp, qtmp, iRec
+     $        ,myThid)
+
+      ELSE
+         CALL NF90IO_FILL_4D(ncid, cdiag(ndId), qtmp, iRec,
+     $        myThid)
+      ENDIF
+      
+      err = nf90_close(ncid)
+      CALL nf90ERR(err, "Closing netcdf file",myThid)
+
+#endif /*  ALLOW_NF90IO  */
+
+      RETURN
+      END

--- a/pkg/diagnostics/diagnostics_nf90io_out.F
+++ b/pkg/diagnostics/diagnostics_nf90io_out.F
@@ -28,12 +28,14 @@ C     !USES:
       IMPLICIT NONE
 #include "SIZE.h"
 #include "EEPARAMS.h"
+#include "EESUPPORT.h"
 #include "PARAMS.h"
 #include "GRID.h"
 #include "DIAGNOSTICS_SIZE.h"
 #include "DIAGNOSTICS.h"
 #ifdef ALLOW_NF90IO
-#include "mpif.h"
+#include "NF90IO.h"
+C #include "mpif.h"
 C #include "NF90IO.h"
 #endif
 
@@ -44,7 +46,7 @@ C     listId          :: Diagnostics list number being written
 C     ndId            :: diagnostics Id number (in available diagnostics list)
 C     qtmp            :: output-field array to write
 C     incrementRec    :: logical to increment record number or not
-C     timeRec         :: time of start and end of averaging.  
+C     timeRec         :: time of start and end of averaging.
 C     misValLoc       :: local Missing Value
 C     myTime          :: current time of simulation (s)
 C     myIter          :: current iteration number
@@ -95,7 +97,7 @@ c     CHARACTER*(NLEN) dn_blnk
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 c     IF (useMNC .AND. diag_mnc) THEN
 
-C        NF90IO: don't think we need this.  
+C        NF90IO: don't think we need this.
 C        _BEGIN_MASTER( myThid )
 
 C     get the filename
@@ -109,17 +111,17 @@ C      wjay the heck to I do with iRec?
 
 C     Check if fname exists.  This is all we will do - we are big kids.  If the file
 C     exists and its different than this version, then we should have erased it.
-C     Of course I'm stupid and often forget to erase files.  
+C     Of course I'm stupid and often forget to erase files.
       INQUIRE(file=fname(1:iLen),exist=lexist)
       IF (.NOT.lexist) THEN
          CALL NF90IO_INIT_FILE(fname(1:iLen), myThid)
 C        This defines most of the dimensions and all the grid variables.
-C        Basic init doesn't add timestart and timeend variables. Lets 
-C        do that here.         
-         err = nf90_open(fname(1:iLen), IOR(nf90_write, nf90_mpiio),
-     $        ncid,
-     $        comm=MPI_COMM_WORLD,   info=MPI_INFO_NULL)
-         CALL nf90ERR(err, "Open diagnostic nc file to write",myThid)
+C        Basic init doesn't add timestart and timeend variables. Lets
+C        do that here.
+         err = nf90io_open(fname(1:iLen),ncid)
+         CALL nf90ERR(err,
+     $           "Open diagnostic nc file to write",myThid)
+
 C        put in redef mode...
          err = nf90_redef(ncid)
          CALL nf90ERR(err, "Redef mode failed!",myThid)
@@ -137,10 +139,7 @@ C        put in redef mode...
       ENDIF
 
 C OK, open the file and get the netcdf id
-      err = nf90_open(fname(1:iLen), IOR(nf90_write, nf90_mpiio),
-     $     ncid,
-     $     comm=MPI_COMM_WORLD,   info=MPI_INFO_NULL)
-      CALL nf90ERR(err, "Open diagnostic nc file to write",myThid)
+      err = nf90io_open(fname(1:iLen),ncid)
 C     get the variable id
       print *,"getting varid"
       print *,cdiag(ndId)
@@ -177,7 +176,7 @@ C       so here we get i_dimid and j_dimid with the proper dimensions
            err = nf90_inq_dimid(ncid, 'j_g', j_dimid)
            CALL nf90ERR(err, "inq i_dimid",myThid)
          ENDIF
-C        do the same for k_dimid (if necessary) 
+C        do the same for k_dimid (if necessary)
          IF (nLevOutp.EQ.Nr) THEN
             err = nf90_inq_dimid(ncid, 'k', k_dimid)
             CALL nf90ERR(err, "inq k_dimid",myThid)
@@ -204,7 +203,7 @@ C        do the same for k_dimid (if necessary)
 C           Define the one-level variable
             dimids(1:3) =  (/  i_dimid, j_dimid, rec_dimid /)
             err = nf90_def_var(ncid, cdiag(ndId), NF90_DOUBLE,
-     $           dimids(1:3), varid)            
+     $           dimids(1:3), varid)
          ELSE
 C           This is a multi-level diagnostic and we need to define a new
 C           dimension k_level.
@@ -218,14 +217,14 @@ C             we need to define k_level
      $              /),varid)
                CALL nf90ERR(err,"Adding k_level variable",myThid)
                err = nf90_put_att(ncid, varid,
-     $              "standard_name", 
+     $              "standard_name",
      $              "z_grid_index")
-               err = nf90_put_att(ncid, varid, 
+               err = nf90_put_att(ncid, varid,
      $              "long_name",
      $              "z-dimension of the level grid")
 C              Drop out of def mode to fill the values in here
                err = nf90_enddef(ncid)
-               err = nf90_var_par_access(ncid, varid, nf90_collective)
+               err = nf90io_var_par_access(ncid, varid)
                CALL nf90ERR(err, "Setting k variable to par access"
      $              ,myThid)
                err = nf90_put_var(ncid, varid, levs(1:nLevOutp, listId),
@@ -244,12 +243,12 @@ C           Done if we need to define k_level
          CALL nf90ERR(err, "Adding diagsnostic variable",myThid)
 C        add attributes to the newy defined variable
          err = nf90_put_att(ncid, varid,
-     $        "description", 
+     $        "description",
      $        tdiag(ndId))
          CALL nf90ERR(err, "Adding attribute diagnostic variable"
      $        ,myThid)
          err = nf90_put_att(ncid, varid,
-     $        "units", 
+     $        "units",
      $        udiag(ndId))
          CALL nf90ERR(err, "Adding attribute diagnostic variable"
      $        ,myThid)
@@ -259,7 +258,7 @@ C        end definition mode...
       ENDIF
 C     Done init variable.  varid should be set to receive!
 
-C TODO: the mnc routines had a bunch of stuff setting the missing value in here.    
+C TODO: the mnc routines had a bunch of stuff setting the missing value in here.
 C     Need to figure out what record number we are on and increment if we need to
       err = nf90_inq_dimid(ncid, "record", rec_dimid)
       err = nf90_inquire_dimension(ncid, rec_dimid, len=iRec)
@@ -268,34 +267,35 @@ C     Need to figure out what record number we are on and increment if we need t
         iRec = iRec+1
         err = nf90_inq_varid(ncid, "record", varid)
         CALL nf90ERR(err, "Get the record varid",myThid)
-        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90io_var_par_access(ncid, varid)
         err = nf90_put_var(ncid, varid, (/ iRec /), start = (/ iRec /),
      $       count = (/ 1 /) )
         CALL nf90ERR(err, "Write iRec to the record variable",myThid)
 C       TIME: We should add TIMESTART and TIMEEND so that we can spec avg interval
         err = nf90_inq_varid(ncid, "time", varid)
         CALL nf90ERR(err, "Get the time varid",myThid)
-        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90io_var_par_access(ncid, varid)
         err = nf90_put_var(ncid, varid, (/ myTime /), start = (/ iRec /)
      $       ,count = (/ 1 /) )
         CALL nf90ERR(err, "Write time variable",myThid)
+        print *,"Wrote time"
 
         err = nf90_inq_varid(ncid, "timestart", varid)
         CALL nf90ERR(err, "Get the timestart varid",myThid)
-        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90io_var_par_access(ncid, varid)
         err = nf90_put_var(ncid, varid, (/ timeRec(1) /), start = (/
      $       iRec /),count = (/ 1 /) )
         CALL nf90ERR(err, "Write timestart variable",myThid)
         err = nf90_inq_varid(ncid, "timeend", varid)
         CALL nf90ERR(err, "Get the timeend varid",myThid)
-        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90io_var_par_access(ncid, varid)
         err = nf90_put_var(ncid, varid, (/ timeRec(2) /), start = (/
      $       iRec /),count = (/ 1 /) )
         CALL nf90ERR(err, "Write timeend variable",myThid)
 C       ITERATION
         err = nf90_inq_varid(ncid, "iter", varid)
         CALL nf90ERR(err, "Get the time varid",myThid)
-        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90io_var_par_access(ncid, varid)
         err = nf90_put_var(ncid, varid, (/ myIter /), start = (/ iRec /)
      $       ,count = (/ 1 /) )
         CALL nf90ERR(err, "Write iter variable",myThid)
@@ -313,7 +313,7 @@ C     Write the data
          CALL NF90IO_FILL_4D(ncid, cdiag(ndId), qtmp, iRec,
      $        myThid)
       ENDIF
-      
+
       err = nf90_close(ncid)
       CALL nf90ERR(err, "Closing netcdf file",myThid)
 

--- a/pkg/diagnostics/diagnostics_out.F
+++ b/pkg/diagnostics/diagnostics_out.F
@@ -79,6 +79,7 @@ c     COMMON /LOCAL_DIAGNOSTICS_OUT/ qtmp1
       INTEGER prec, nRec, nTimRec
       _RL     timeRec(2)
       _RL     tmpLoc
+      LOGICAL incrementRec
 #ifdef ALLOW_MDSIO
       LOGICAL glf
 #endif
@@ -428,6 +429,29 @@ C         a hack not to write meta files now: pass -nRec < 0 to MDS_WRITE S/R
            ENDIF
           ENDIF
 #endif /*  ALLOW_MNC  */
+
+#ifdef ALLOW_NF90IO
+          IF (useNF90io .AND. diag_nf90io) THEN
+             IF (md.EQ.1) THEN
+C               then this is the first diagnostics of this list element.
+                incrementRec=.TRUE.
+             ELSE
+                incrementRec=.FALSE.
+             ENDIF
+             IF ( ppFld.LE.1 ) THEN
+                CALL DIAGNOSTICS_NF90IO_OUT(
+     I               NrMax, nLevOutp, listId, ndId,
+     I               qtmp1, incrementRec, timeRec,
+     I               undefRL, myTime, myIter, myThid )
+             ELSE
+                CALL DIAGNOSTICS_NF90IO_OUT(
+     I               NrMax, nLevOutp, listId, ndId,
+     I               qtmp2, incrementRec, timeRec,
+     I               undefRL, myTime, myIter, myThid )
+             ENDIF
+          ENDIF
+#endif /*  ALLOW_NF90IO  */
+
 
 C--     end of Processing Fld # md
         ENDIF

--- a/pkg/diagnostics/diagnostics_readparms.F
+++ b/pkg/diagnostics/diagnostics_readparms.F
@@ -94,7 +94,7 @@ C--   full level output:
      &     averagingFreq, averagingPhase, repeatCycle,
      &     missing_value, missing_value_int,
      &     levels, fields, fileName, fileFlags,
-     &     dumpAtLast, diag_mnc, useMissingValue,
+     &     dumpAtLast, diag_mnc, diag_nf90io, useMissingValue,
      &     diagCG_maxIters, diagCG_resTarget,
      &     diagCG_pcOffDFac, diagCG_prtResFrq, xPsi0, yPsi0,
      &     diag_pickup_read,     diag_pickup_write,
@@ -152,6 +152,7 @@ c       missing_value(l)     = UNSET_RL
       diagLoc_ioUnit = 0
       dumpAtLast   = .FALSE.
       diag_mnc     = useMNC
+      diag_nf90io  = useNF90io
       useMissingValue = .FALSE.
       diag_pickup_read      = .FALSE.
       diag_pickup_write     = .FALSE.
@@ -256,10 +257,15 @@ C     Fix to avoid running without getting any output:
       diag_mnc   = .FALSE.
       diagSt_mnc = .FALSE.
 #endif
+#ifndef ALLOW_NF90IO
+C     Fix to avoid running without getting any output:
+      diag_nf90io   = .FALSE.
+#endif
 
 C     Fill Diagnostics Common Block with Namelist Info
       diagSt_mnc = diagSt_mnc .AND. useMNC
-      diag_mdsio = (.NOT. diag_mnc) .OR. outputTypesInclusive
+      diag_mdsio = (.NOT. (diag_mnc .OR. diag_nf90io) .OR.
+     $     outputTypesInclusive)
       diag_pickup_read_mnc  = diag_pickup_read_mnc .AND. diag_mnc
       diag_pickup_write_mnc = diag_pickup_write_mnc .AND. diag_mnc
       diag_pickup_read_mdsio  =

--- a/pkg/nf90io/.oldcode/NF90IO.h
+++ b/pkg/nf90io/.oldcode/NF90IO.h
@@ -1,0 +1,45 @@
+C $Header: /u/gcmpack/MITgcm/pkg/kl10/KL10.h,v 1.1 2014/07/30 03:28:05 jmc Exp $
+C $Name: checkpoint66d $
+
+#ifdef ALLOW_NF90IO
+
+CBOP
+C !ROUTINE: NF90IO.h
+
+C !DESCRIPTION: \bv
+C     /==========================================================\
+C     | NF90IO.h                                                   |
+C     | o Basic header for Netcdf/Fortran90/Parallel i/o           |
+C     \==========================================================/
+
+C-----------------------------------------------------------------------
+C
+C Constants that could be set in a data.nf90io
+C
+C     !!!! NOT IMPLIMENTED !!!! 
+C     See pkg/diagnostics/diagnostics_nf90io_out.F
+C
+C     NF90ioFileName - name of the netcdf file to write
+C     NF90ioAppend - whether to append to an existing file (default=False)
+C
+C-----------------------------------------------------------------------
+C \ev
+CEOP
+
+
+      CHARACTER*(MAX_LEN_FNAM) NF90ioFilename
+      LOGICAL   NF90ioAppend
+C Variable to globally keep track of if we need to create the netcdf file.
+      LOGICAL   NF90ioFileCreated, NF90ioisOn, NF90ioDump 
+
+      COMMON /NF90IO_PARMS/
+     &     NF90ioFilename,
+     &     NF90ioAppend,
+     &     NF90ioFileCreated,
+     &     NF90ioisOn,
+     &     NF90ioDump
+
+
+
+
+#endif /* ALLOW_NF90IO */

--- a/pkg/nf90io/.oldcode/NF90IO_OPTIONS.h
+++ b/pkg/nf90io/.oldcode/NF90IO_OPTIONS.h
@@ -1,0 +1,31 @@
+C $Header: /u/gcmpack/MITgcm/pkg/kl10/KL10_OPTIONS.h,v 1.1 2014/07/30 03:28:05 jmc Exp $
+C $Name: checkpoint66d $
+
+C     *==========================================================*
+C     | NF90IO_OPTIONS.h
+C     | o CPP options file for NF90IO package.
+C     *==========================================================*
+C     | Use this file for selecting options within the NF90IO
+C     | package.
+C     *==========================================================*
+
+C =====================================================
+C !!!!  NOT IMPLIMENTED   !!!!
+C
+C As it stands, this routine is not called or needed.  All NF90IO is done
+C via the diagnostics package.  i.e. see 
+C      pkg/diagnostics/diagnostics_nf90io_out.F
+C
+C  This call would go in model/src/packages_readparms.F
+C ======================================================
+
+#ifndef NF90IO_OPTIONS_H
+#define NF90IO_OPTIONS_H
+#include "PACKAGES_CONFIG.h"
+#include "CPP_OPTIONS.h"
+
+#ifdef ALLOW_NF90IO
+C     Package-specific Options & Macros go here
+
+#endif /* ALLOW_NF90IO */
+#endif /* NF90IO_OPTIONS_H */

--- a/pkg/nf90io/.oldcode/READEME.rst
+++ b/pkg/nf90io/.oldcode/READEME.rst
@@ -1,0 +1,6 @@
+NF90IO .oldcode
+===============
+
+This is some old code from the original implimentation of this package.  This was meant to be called via `model/src/write_state.F`, and there was meant to be a `data.nf90io` that allowed the user to set the netcdf filename.  
+
+However, the maintainers suggested the right way to do this was to make `nf90io` an option of `pkg/diagnostics`. So, that is how the package is now implimented.  This code is kept here in case we decide to re-add the ability to dump the state variables.  

--- a/pkg/nf90io/.oldcode/nf90io_readparms.F
+++ b/pkg/nf90io/.oldcode/nf90io_readparms.F
@@ -1,0 +1,103 @@
+C $Header: /u/gcmpack/MITgcm/pkg/kl10/kl10_readparms.F,v 1.1 2014/07/30 03:28:05 jmc Exp $
+C $Name: checkpoint66d $
+
+#include "NF90IO_OPTIONS.h"
+
+CBOP
+C !ROUTINE: NF90IO_READPARMS
+
+C =====================================================
+C !!!!  NOT IMPLIMENTED   !!!!
+C
+C As it stands, this routine is not called or needed.  All NF90IO is done
+C via the diagnostics package.  i.e. see 
+C      pkg/diagnostics/diagnostics_nf90io_out.F
+C
+C  This call would go in model/src/packages_readparms.F
+C ======================================================
+
+
+C !INTERFACE: ==========================================================
+      SUBROUTINE NF90IO_READPARMS( myThid )
+
+C !DESCRIPTION:
+C     Initialize KL10 parameters, read in data.kl10
+
+C !USES: ===============================================================
+      IMPLICIT NONE
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "NF90IO.h"
+#include "PARAMS.h"
+
+C !INPUT PARAMETERS: ===================================================
+C  myThid               :: thread number
+      INTEGER myThid
+
+C !OUTPUT PARAMETERS: ==================================================
+C  none
+
+#ifdef ALLOW_NF90IO
+
+C !LOCAL VARIABLES: ====================================================
+C  iUnit                :: unit number for I/O
+C  msgBuf               :: message buffer
+      INTEGER iUnit
+      CHARACTER*(MAX_LEN_MBUF) msgBuf
+CEOP
+
+      NAMELIST /NF90IO_PARM01/
+     &     NF90ioFilename,
+     &     NF90ioAppend
+
+      IF ( .NOT.useNF90IO ) THEN
+C-    pkg nf90io is not used
+        _BEGIN_MASTER(myThid)
+C-    Track pkg activation status:
+         NF90ioisON = .FALSE.
+C     print a (weak) warning if data.nf90io is found
+         CALL PACKAGES_UNUSED_MSG( 'NF90IO', ' ', ' ' )
+        _END_MASTER(myThid)
+        RETURN
+      ENDIF
+
+      _BEGIN_MASTER(myThid)
+
+C This routine has been called by the main model so we set our
+C internal flag to indicate we are in business
+      NF90ioisON = .TRUE.
+
+C Set defaults values for parameters in KL10.h
+      NF90ioFilename  = "ModelOut.nc"
+      NF90ioAppend    = .FALSE.
+C Open and read the data.nf90io file
+      WRITE(msgBuf,'(A)') ' NF90IO_READPARMS: opening data.nf90io'
+      CALL PRINT_MESSAGE(msgBuf, standardMessageUnit,
+     &                   SQUEEZE_RIGHT , 1)
+      CALL OPEN_COPY_DATA_FILE(
+     I                   'data.nf90io', 'NF90IO_READPARMS',
+     O                   iUnit,
+     I                   myThid )
+      READ(UNIT=iUnit,NML=NF90IO_PARM01)
+      WRITE(msgBuf,'(A)')
+     &  ' NF90IO_READPARMS: finished reading data.nf90io'
+      CALL PRINT_MESSAGE(msgBuf, standardMessageUnit,
+     &                   SQUEEZE_RIGHT , 1)
+
+C Close the open data file
+      CLOSE(iUnit)
+      _END_MASTER(myThid)
+
+C Everyone else must wait for the parameters to be loaded
+      _BARRIER
+
+C Now set-up any remaining parameters that result from the input parameters
+      IF ( NF90ioAppend) THEN
+       WRITE(msgBuf,'(A)') 'NF90ioAppend not implimented yet.  Soon!'
+       CALL PRINT_ERROR( msgBuf , 1)
+       STOP 'ABNORMAL END: S/R NF90IO_READPARMS'
+      ENDIF
+#endif /* ALLOW_KL10 */
+
+      RETURN
+      END

--- a/pkg/nf90io/.oldcode/nf90io_write_rec.F
+++ b/pkg/nf90io/.oldcode/nf90io_write_rec.F
@@ -1,0 +1,282 @@
+
+#include "PACKAGES_CONFIG.h"
+#include "CPP_OPTIONS.h"
+
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+CBOP
+!ROUTINE: NF90IO_WRITE_REC.F
+C
+C     !DESCRIPTION:
+C     *==========================================================*
+C     | NF90IO_WRITE_REC                                         |
+C     *==========================================================*
+C     | 
+C     | !!!! NOT IMPLIMENTED      !!! 
+C     | 
+C     | In an initial version of this package, this was called in|
+C     | model/src/write_state.F
+C     |  
+C     | Dropped in favour of implimenting as an output for       |
+C     | pkg/diagnostics. 
+C     |
+C     | Writes model state.  If it is the first record, then     |
+C     | initialize the file and state variables.   Uses helper   |
+C     | routines in NF90IO_UTIL and NF90IO_INIT_FILE.F           |
+C     *==========================================================*
+CEOP
+
+      SUBROUTINE NF90IO_WRITE_REC ( iRec, myTime, myIter, myThid )
+        use netcdf
+        IMPLICIT NONE
+
+#include "mpif.h"
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "NF90IO.h"
+#include "PARAMS.h"
+#include "GRID.h"
+#include "DYNVARS.h"
+#ifdef ALLOW_NONHYDROSTATIC
+#include "NH_VARS.h"
+#endif
+
+        INTEGER iRec
+        _RL     myTime
+        INTEGER myThid
+        INTEGER myIter
+
+        INTEGER mode_flag, ncid, err, i, j, k, t
+        INTEGER bi, bj
+        INTEGER i_dimid, j_dimid, k_dimid, dimids(4), varid
+        INTEGER ig_dimid, jg_dimid, kl_dimid, ku_dimid, kp1_dimid
+        INTEGER start(4), count(4), rec_dimid
+        LOGICAL iAmDoingIO
+        character*(MAX_LEN_MBUF) msgbuf
+        _RL     a(sNx,sNy,Nr)
+        _RL     is(sNx+10)
+        _RL     js(sNy+10)
+        _RL     ks(Nr+10)
+
+        if (iRec.EQ.1) then
+C          initialize this new file...
+          CALL NF90IO_INIT_FILE(NF90ioFilename, myThid)
+C     Define dynvars:
+          err = nf90_open(NF90ioFilename, IOR(nf90_write, nf90_mpiio),
+     $         ncid,
+     $         comm = MPI_COMM_WORLD,   info = MPI_INFO_NULL)
+          CALL nf90ERR(err, "Open nc file to write",myThid)
+          err = nf90_redef(ncid)
+
+C     Get the dimension ids we will need.  Could do this with globals
+C     but this is just as easy.   
+          err = nf90_inq_dimid(ncid, 'i', i_dimid)
+          CALL nf90ERR(err, "inq i_dimid",myThid)
+          err = nf90_inq_dimid(ncid, 'i_g', ig_dimid)
+          CALL nf90ERR(err, "inq i_g_dimid",myThid)
+          err = nf90_inq_dimid(ncid, 'j', j_dimid)
+          CALL nf90ERR(err, "inq j_dimid",myThid)
+          err = nf90_inq_dimid(ncid, 'j_g', jg_dimid)
+          CALL nf90ERR(err, "inq j_g_dimid",myThid)
+          err = nf90_inq_dimid(ncid, 'k', k_dimid)
+          CALL nf90ERR(err, "inq k_dimid",myThid)
+          err = nf90_inq_dimid(ncid, 'k_u', ku_dimid)
+          CALL nf90ERR(err, "inq k_u_dimid",myThid)
+          err = nf90_inq_dimid(ncid, 'k_l', kl_dimid)
+          CALL nf90ERR(err, "inq k_l_dimid",myThid)
+          err = nf90_inq_dimid(ncid, 'k_p1', kp1_dimid)
+          CALL nf90ERR(err, "inq k_p1_dimid",myThid)
+          err = nf90_inq_dimid(ncid, 'record', rec_dimid)
+          CALL nf90ERR(err, "inq record_dimid",myThid)
+
+          dimids =  (/  i_dimid, j_dimid, k_dimid, rec_dimid /)
+          err = nf90_def_var(ncid, "Theta", NF90_DOUBLE, dimids, varid)
+          CALL nf90ERR(err, "Adding Theta variable",myThid)
+          err = nf90_put_att(ncid, varid,
+     $         "standard_name", 
+     $         "sea_water_potential_temperature")
+          err = nf90_put_att(ncid, varid, 
+     $         "long_name",
+     $         "Potential Temperature")
+          err = nf90_put_att(ncid, varid, 
+     $         "units",
+     $         "degree_Celcius")
+          CALL nf90ERR(err,"Setting attributes",myThid)
+
+          err = nf90_def_var(ncid, "Salt", NF90_DOUBLE, dimids, varid)
+          CALL nf90ERR(err, "Adding Salt variable",myThid)
+          err = nf90_put_att(ncid, varid,
+     $         "standard_name", 
+     $         "sea_water_salinity")
+          err = nf90_put_att(ncid, varid, 
+     $         "long_name",
+     $         "Salinity")
+          err = nf90_put_att(ncid, varid, 
+     $         "units",
+     $         "psu")
+          CALL nf90ERR(err,"Setting attributes",myThid)
+
+          err = nf90_def_var(ncid, "PH", NF90_DOUBLE, dimids, varid)
+          CALL nf90ERR(err, "Adding PH variable",myThid)
+          err = nf90_put_att(ncid, varid,
+     $         "standard_name", 
+     $         "sea_water_dynamic_pressure")
+          err = nf90_put_att(ncid, varid, 
+     $         "long_name",
+     $         "Hydrostatic Pressure Pot.(p/rho) Anomaly")
+          err = nf90_put_att(ncid, varid, 
+     $         "units",
+     $         "m2 s-2")
+          err = nf90_put_att(ncid, varid, 
+     $         "coordinate",
+     $         "XC YC Z")
+          CALL nf90ERR(err,"Setting attributes",myThid)
+
+          dimids =  (/  ig_dimid, j_dimid, k_dimid, rec_dimid /)
+          err = nf90_def_var(ncid, "U", NF90_DOUBLE, dimids, varid)
+          CALL nf90ERR(err, "Adding U variable",myThid)
+          err = nf90_put_att(ncid, varid,
+     $         "standard_name", 
+     $         "sea_water_x_velocity")
+          err = nf90_put_att(ncid, varid, 
+     $         "long_name",
+     $         "Zonal Component of Velocity")
+          err = nf90_put_att(ncid, varid, 
+     $         "units",
+     $         "m s-1")
+          CALL nf90ERR(err,"Setting attributes",myThid)
+
+          dimids =  (/  i_dimid, jg_dimid, k_dimid, rec_dimid /)
+          err = nf90_def_var(ncid, "V", NF90_DOUBLE, dimids, varid)
+          CALL nf90ERR(err, "Adding V variable",myThid)
+          err = nf90_put_att(ncid, varid,
+     $         "standard_name", 
+     $         "sea_water_y_velocity")
+          err = nf90_put_att(ncid, varid, 
+     $         "long_name",
+     $         "Meridional Component of Velocity")
+          err = nf90_put_att(ncid, varid, 
+     $         "units",
+     $         "m s-1")
+          CALL nf90ERR(err,"Setting attributes",myThid)
+
+          dimids =  (/  i_dimid, j_dimid, kl_dimid, rec_dimid /)
+          err = nf90_def_var(ncid, "W", NF90_DOUBLE, dimids, varid)
+          CALL nf90ERR(err, "Adding W variable",myThid)
+          err = nf90_put_att(ncid, varid,
+     $         "standard_name", 
+     $         "sea_water_z_velocity")
+          err = nf90_put_att(ncid, varid, 
+     $         "long_name",
+     $         "Vertica Component of Velocity")
+          err = nf90_put_att(ncid, varid, 
+     $         "units",
+     $         "m s-1")
+          CALL nf90ERR(err,"Setting attributes",myThid)
+
+          dimids(1:3) =  (/  i_dimid, j_dimid, rec_dimid /)
+          err = nf90_def_var(ncid, "Eta", NF90_DOUBLE, dimids(1:3),
+     $         varid)
+          CALL nf90ERR(err, "Adding Eta variable",myThid)
+          err = nf90_put_att(ncid, varid,
+     $         "standard_name", 
+     $         "ETAN")
+          err = nf90_put_att(ncid, varid, 
+     $         "long_name",
+     $         "Surface Height Anomaly")
+          err = nf90_put_att(ncid, varid, 
+     $         "units",
+     $         "m")
+          CALL nf90ERR(err,"Setting attributes",myThid)
+
+          dimids(1:3) =  (/  i_dimid, j_dimid, rec_dimid /)
+          err = nf90_def_var(ncid, "PHL", NF90_DOUBLE, dimids(1:3),
+     $         varid)
+          CALL nf90ERR(err, "Adding PHL variable",myThid)
+          err = nf90_put_att(ncid, varid,
+     $         "standard_name", 
+     $         "sea_water_dynamic_pressure_at_sea_floor")
+          err = nf90_put_att(ncid, varid, 
+     $         "long_name",
+     $         "Bottom Pressure Pot.(p/rho) Anomaly")
+          err = nf90_put_att(ncid, varid, 
+     $         "units",
+     $         "m2 s-2")
+          CALL nf90ERR(err,"Setting attributes",myThid)
+
+#ifdef ALLOW_NONHYDROSTATIC
+          IF (nonHydroStatic) THEN
+             dimids =  (/  i_dimid, j_dimid, k_dimid, rec_dimid /)
+             err = nf90_def_var(ncid, "PNH", NF90_DOUBLE, dimids, varid)
+             CALL nf90ERR(err, "Adding PNH variable",myThid)
+             err = nf90_put_att(ncid, varid,
+     $            "standard_name", 
+     $            "sea_water_nonhydrostatic_dynamic_pressure")
+             err = nf90_put_att(ncid, varid, 
+     $            "long_name",
+     $            "Non-Hydrostatic Pressure Pot.(p/rho) Anomaly")
+             err = nf90_put_att(ncid, varid, 
+     $            "units",
+     $            "m2 s-2")
+             CALL nf90ERR(err,"Setting attributes",myThid)
+          ENDIF
+#endif /* ALLOW_NONHYDROSTATIC */
+
+
+          err = nf90_enddef(ncid)
+          err = nf90_close(ncid)
+          CALL nf90ERR(err, "Closing netcdf file",myThid)          
+        endif
+C       /endif the first record.
+C
+C       Now write the data
+C
+        err = nf90_open(NF90ioFilename, IOR(nf90_write, nf90_mpiio),
+     $       ncid, comm=MPI_COMM_WORLD, info=MPI_INFO_NULL)
+        CALL nf90ERR(err, "Open nc file to write",myThid)
+
+C update the record
+        err = nf90_inq_varid(ncid, "record", varid)
+        CALL nf90ERR(err, "Get the record varid",myThid)
+        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90_put_var(ncid, varid, (/ iRec /), start = (/ iRec /),
+     $       count = (/ 1 /) )
+        CALL nf90ERR(err, "Write iRec to the record variable",myThid)
+        
+        err = nf90_inq_varid(ncid, "time", varid)
+        CALL nf90ERR(err, "Get the time varid",myThid)
+        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90_put_var(ncid, varid, (/ myTime /), start = (/ iRec /)
+     $       ,count = (/ 1 /) )
+        CALL nf90ERR(err, "Write time variable",myThid)
+        
+        err = nf90_inq_varid(ncid, "iter", varid)
+        CALL nf90ERR(err, "Get the iter varid",myThid)
+        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90_put_var(ncid, varid, (/ myIter /), start = (/ iRec /)
+     $       ,count = (/ 1 /) )
+        CALL nf90ERR(err, "Write iter variable",myThid)
+                
+C start 3-D  variables....
+C TODO: There are some other variables and logic that should 
+C       be copied from write_state.F
+        CALL NF90IO_FILL_3D(ncid, "Eta", etaN, iRec, myThid)
+        CALL NF90IO_FILL_3D(ncid, "PHL", phiHydLow, iRec, myThid)
+        CALL NF90IO_FILL_4D(ncid, "Theta", theta, iRec, myThid)
+        CALL NF90IO_FILL_4D(ncid, "U", Uvel, iRec, myThid)
+        CALL NF90IO_FILL_4D(ncid, "V", Vvel, iRec, myThid)
+        CALL NF90IO_FILL_4D(ncid, "W", Wvel, iRec, myThid)
+        CALL NF90IO_FILL_4D(ncid, "PH", totPhiHyd, iRec, myThid)
+        CALL NF90IO_FILL_4D(ncid, "Salt", salt, iRec, myThid)
+
+#ifdef ALLOW_NONHYDROSTATIC
+          IF (nonHydroStatic) THEN
+             CALL NF90IO_FILL_4D(ncid, "PNH", phi_nh, iRec, myThid)
+          ENDIF
+#endif /* ALLOW_NONHYDROSTATIC */
+
+        err = nf90_close(ncid)
+        CALL nf90ERR(err, "Closing netcdf file",myThid)
+
+      RETURN
+      END

--- a/pkg/nf90io/NF90IO.h
+++ b/pkg/nf90io/NF90IO.h
@@ -1,0 +1,7 @@
+C ======================================================================
+C  Defines for NF90IO.h
+
+
+C Functions that returns integer defined in nf90io_utils.F
+      INTEGER NF90IO_VAR_PAR_ACCESS
+      INTEGER NF90IO_OPEN

--- a/pkg/nf90io/README.rst
+++ b/pkg/nf90io/README.rst
@@ -1,0 +1,173 @@
+NetCDF90 Parallel Output: NF90IO
+********************************
+
+The ``nf90io`` package implements parallel oputput for the diagnostics package.  It writes one NetCDF file per ``filename`` specified in ``data.diagnostics``, unlike the older ``mnc`` package, which writes one file per tile of the model domain, and requires post-processing to merge into one file:
+
+As example, consider the following ``data.diagnostic``:
+
+::
+
+  &diagnostics_list
+  # 3D variables.
+  filename(1)   = 'statevars'
+  frequency(1)  = -1860,
+  timePhase(1)      =  0,
+  fields(1:2,1) = 'UVEL    ',
+                  'THETA   ',
+  #
+  filename(2)   = 'statevars2d'
+  frequency(2)  = -1860,
+  timePhase(2)  = 0,
+  fields(1:2,2) = 'ETAN    ',
+                  'PHIBOT  ',
+  /
+
+If NF90IO is turned on, then the model will produce two NetCDF files ``statevars.nc`` and ``statevars2d.nc`` containing the diagnostics.  Files can, of course, have many more diagnostics.  The NetCDF files also contain all the grid information for the model.
+
+The resulting file is structured like this example:
+
+::
+
+  Dimensions:    (i: 80, i_g: 80, j: 1, j_g: 1, k: 25, k_l: 25, k_p1: 26, k_u: 25, record: 53)
+  Coordinates:
+    * record     (record) int32 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 ...
+    * i          (i) int32 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 ...
+    * i_g        (i_g) int32 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 ...
+    * j          (j) int32 0
+    * j_g        (j_g) int32 0
+    * k          (k) int32 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 ...
+    * k_l        (k_l) int32 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 ...
+    * k_u        (k_u) int32 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 ...
+    * k_p1       (k_p1) int32 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 ...
+      XC         (j, i) float64 1.237e+04 3.629e+04 5.859e+04 7.925e+04 ...
+      XG         (j_g, i_g) float64 7.276e-12 2.474e+04 4.785e+04 6.933e+04 ...
+      YC         (j, i) float64 2.5e+03 2.5e+03 2.5e+03 2.5e+03 2.5e+03 ...
+      YG         (j_g, i_g) float64 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 ...
+  Data variables:
+      iter       (record) int32 0 150 300 450 600 750 900 1050 1200 1350 1500 ...
+      time       (record) timedelta64[ns] 00:00:00 00:31:00 01:02:00 01:33:00 ...
+      Depth      (j, i) float64 2e+03 2e+03 2e+03 2e+03 2e+03 2e+03 2e+03 ...
+      Z          (k) float64 -40.0 -120.0 -200.0 -280.0 -360.0 -440.0 -520.0 ...
+      Zu         (k_u) float64 -80.0 -160.0 -240.0 -320.0 -400.0 -480.0 -560.0 ...
+      Zl         (k_l) float64 0.0 -80.0 -160.0 -240.0 -320.0 -400.0 -480.0 ...
+      Zp1        (k_p1) float64 0.0 -80.0 -160.0 -240.0 -320.0 -400.0 -480.0 ...
+      rA         (j, i) float64 1.237e+08 1.155e+08 1.074e+08 9.925e+07 ...
+      rAw        (j, i_g) float64 1.237e+08 1.196e+08 1.115e+08 1.033e+08 ...
+      rAs        (j_g, i) float64 1.237e+08 1.155e+08 1.074e+08 9.925e+07 ...
+      rAz        (j_g, i_g) float64 1.237e+08 1.196e+08 1.115e+08 1.033e+08 ...
+      dxG        (j_g, i) float64 2.474e+04 2.311e+04 2.148e+04 1.985e+04 ...
+      dyG        (j, i_g) float64 2.474e+04 2.311e+04 2.148e+04 1.985e+04 ...
+      dxC        (j, i_g) float64 2.474e+04 2.392e+04 2.229e+04 2.066e+04 ...
+      dyC        (j_g, i) float64 2.474e+04 2.392e+04 2.229e+04 2.066e+04 ...
+      drC        (k_p1) float64 40.0 80.0 80.0 80.0 80.0 80.0 80.0 80.0 80.0 ...
+      drF        (k) float64 80.0 80.0 80.0 80.0 80.0 80.0 80.0 80.0 80.0 80.0 ...
+      hFacC      (k, j, i) float64 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 ...
+      hFacW      (k, j, i_g) float64 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 ...
+      hFacS      (k, j_g, i) float64 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 ...
+      PHrefC     (k) float64 392.4 1.177e+03 1.962e+03 2.747e+03 3.532e+03 ...
+      PHrefF     (k_p1) float64 0.0 784.8 1.57e+03 2.354e+03 3.139e+03 ...
+      timestart  (record) float64 0.0 1.86e+03 3.72e+03 5.58e+03 7.44e+03 ...
+      timeend    (record) float64 2.176e-314 2.176e-314 2.176e-314 2.176e-314 ...
+      UVEL       (record, k, j, i_g) float64 0.338 0.338 0.0 0.0 0.0 0.0 0.0 ...
+      THETA      (record, k, j, i) float64 26.9 26.9 26.9 26.9 26.9 26.9 26.9 ...
+  Attributes:
+      the_run_name:
+      build_user:    jklymak
+      build_host:    JMKMBP.local
+      build_date:    Fri Jul 28 18:37:18 PDT 2017
+      MITgcm_URL:    http://mitgcm.org
+      history:       Saved from nf90io
+
+The co-ordinates are kept deliberately abstract ``i``, ``j`` etc because various non-Cartesian grids are possible in the model.  The variables ``time`` are in seconds, and the variables ``timestart`` and ``timeend`` indicate the start and end of an averaging period for averaged diagnostics.  Note that variables are assigned dimensions based on their location on the Arakawa C-Grid, so in this example ``UVEL`` has a third spatial dimension ``i_g`` instead of ``i`` to indicate that it is on the west side of the cell faces.  ``VVEL`` would be on ``j_g`` instead of ``j`` to indicate it is located on the south side of cell faces.  Note how the first element of ``XG`` is smaller than the first element of ``XC``.
+
+Using NF90IO
+-------------
+
+NF90IO can be turned on or off at compile time with ``code/packages.conf`` or using ``genmake2 -enable=nf90io``.  There is a test to make sure NF90IO can be compiled in ``genmake2`` (see below).
+
+It can be turned on or off at run time in ``input/data.pkg`` by setting ``useNF90IO=.TRUE.``.
+
+Finally it can be turned on or off explicitly inside ``input/data.diagnostics`` by setting ``diag_nf90io=.TRUE.`` or ``.FLASE.``.  By default it is set to ``useNF90IO``, so it is just as easy to control from ``input/data.pkg``
+
+Currently there is no ``input/data.nf90io`` because there are no package-specific options to turn on or off.  This may change in the future.
+
+Note that NF90IO output can be mixed with MDSIO and MNC outputs.  If ``input/data.pkg`` has ``useMNC=.TRUE.`` and ``useNF90IO=.TRUE`` then both styles of files will be written unless explicitly turned off in ``input/data.diagnostics``.  Users probably don't want to output both types of files, so if ``useMNC=.TRUE.`` and ``useNF90IO=.TRUE`` are set in ``input/data.pkg`` then in ``input/data.diagnostics`` users probably want to set ``diag_nf90io=.FALSE.`` *or* ``diag_mnc=.FALSE.``.
+
+To suppress MDS output (binary files), the ``input/data`` file should be edited to have ``dumpFreq=0`` and ``dumpInitAndLast=.FALSE.`` in the parameter list ``&PARM03``.
+
+NF90IO Appends to Existing Files
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+NF90IO *appends* to existing files.  In the example above, if ``statevars.nc`` exists, and the model is re-run, the file will not be erased and started over again, but will instead have new records appended to it.  This will lead to duplicated information if the model is restarted from scratch.
+
+Conversely, it allows the model to be restarted from a pickup and the original file to be appended to, keeping all model output in one place.
+
+If you don't want the old file to be appended to, then rename or delete the old file before running the model or set a new ``filename`` in ``input/data.diagnostics``.
+
+Compiling NF90IO
+----------------------
+
+NF90IO is based on `NetCDF F90 <https://www.unidata.ucar.edu/software/netcdf/netcdf-4/newdocs/netcdf-f90.html>`_ routines.  It requires ``netcdf`` to be built for Fortran, linked to a ``hdf5`` library that has been built with parallel support.  You should know where the NetCDF library and include files are for these libraries are so you can specify them in your ``build_options/yourmachine`` file.  i.e. if these files are in ``$NETCDF_DIR`` then you should have something like
+
+::
+
+  INCLUDE="-I$NETCDF_DIR/include -I$MPI_DIR/include"
+  LIBS="-L$NETCDF_DIR/libs"
+
+in that file.
+
+The script ``genmake2`` will check to see if NF90IO can be compiled using your ``build_options``.  If that check fails, then NF90IO will be made unavailable.  During the ``genmake2`` process you should get a series of messages like:
+
+::
+
+  Can we create NetCDF-enabled binaries...  yes
+  Can we create NF90-enabled binaries...  yes
+  Can we create LAPACK-enabled binaries...  no
+
+If the ``NF90-enabled binaries`` message returns ``yes`` then the variable ``HAVE_NF90IO`` is set to true and NF90IO will be able to be compiled.
+
+NF90IO vs MNC and MDSIO
+-----------------------
+
+Which output format should you choose for the MITgcm?  MNC is the older NetCDF interface which makes NetCDF 3.x files.  MDSIO writes binary files.  Which output you choose depends on your complier environment, your model output, and your processing environment.
+
+MDSIO is simple, and has a good set of tools built around it.  On the other hand, there are few tools available to handle very large MDSIO binary files.  This can be an issue when model output becomes larger than memory space in the analysis computer.  Many supercomputing systems do not allow users to access swap space memory, so memory is confined to the available memory on the machine, and even one snapshot from a modern MITgcm data set can exceed 50 Gb if all variables are loaded.  MDSIO also has the plus/minus of storing each time step as a unique file.  This is sometimes useful if you just want a few snapshots near the end of a run, but has obvious archiving drawbacks and is less convenient than accessing records in a single NetCDF file.
+
+MNC writes NetCDF files, and has all the advantages of a standard well-used file standard, including many large tool suites.  Modern versions of these tool suites allow "chunked" data operations whereby data is only loaded into machine memory on an as-needed basis.  (i.e. in python the ``xarray`` plus ``dask`` libraries do this.  Matlab has the ability to read chunked arrays as well). MNC is also somewhat more flexible than NF90IO, with options controlling file sizes and file directories (NF90IO could add such options in the future).
+
+Conversely, MNC cannot do parallel output operations, so each MPI processor has to write to a separate file.  So instead of ``statevars.nc`` in the example above, a series of files are written ``statevars.0000000000.t0001``, ``statevars.0000000000.t0002``, etc, one file for each tile in the simulation.   So, a 1024-core job  produces 1024 NetCDF files, one for each core.  In order to make a single NetCDF file, these files need to be ``glued`` together (by python and/or matlab scripts) in post-processing.  For large files on memory-constrained machines these scripts can fail.
+
+The memory drawback of both the MDSIO and MNC approaches is what inspired NF90IO.  NF90IO creates a *single* file for each diagnostic, and these files can be arbitrarily large.
+
+When would you *not* use NF90IO?  If you don't have a parallel NetCDF library is one case.  If your file system cannot support very large files would be another case.  The other limitation of NF90IO is that it only (currently) supports ``pkg/diagnostics`` controlled output.  Using ``pkg/diagnostics`` is *highly* recommended, but there may be good reasons to not use it in certain cases.
+
+Dealing with Large NetCDF Files
+-------------------------------
+
+The NF90IO style output can lead to very large NetCDF files depending on the values of ``frequency`` in  ``input/data.diagnostics`` and the size of the simulation. Transfering such large files can be difficult, and often users are just interested in part of the output.  There are two strategies here:
+
+  1. run the model to the time of interest with large values of ``frequency`` in ``input/data.diagnostics``, and then restart from a pickup file specifying new values of ``frequency`` and presumably specfying new filenames for the diagnostics (or moving/deleting the old file).
+
+  For instance to spinup for 100 days, and then start saving output in ``input/data`` one would specify ``endTime=8640000,`` and ``pickupFreq=8640000``, and in ``input/diagnostics`` the values for the frequency would be set to something large i.e. ``frequency(1)=864000,``.  Then if the user wanted hourly output they would edit ``input/data`` to have ``startTime=8640000``, ``endTime=8812800`` and in ``input/diagnostics`` we would set ``frequency(1)=3600``.  We may also want to move the NetCDF file that was cerated in the spinup stage to ``spinupstatevars.nc`` so the high temporal resolution data could be saved in ``statevars.nc``.
+
+  2. Use a tool like ``ncea`` in the `NCO toolbox <http://nco.sourceforge.net>`_ to subset the ``time`` or ``record`` variables
+
+  ::
+
+    ncea -F -d record,first,last statevars.nc statevarssubset.nc
+
+  ``ncea`` can also be used to make the files smaller in space (see the online documentation for this utility).
+
+  A similar effect can be carried out in Python using the `xarray <http://xarray.pydata.org/en/stable/>`_ package.  For instance
+
+  ::
+
+    import xarray as xr
+
+    ds = xr.open_dataset('statevars.nc')
+    ds = ds.isel(i=range(40,50), i_g=range(40,50), record=range(50,54))
+    ds.to_netcdf('small.nc')
+
+  subsets the files on records 50 to 53, and the x co-ordinates between index 40 and 49, making a much smaller file.  Slices in various dimensions can be selected in a similar manner.  Because `xarray <http://xarray.pydata.org/en/stable/>`_ uses `dask <https://dask.pydata.org/en/latest/>`_ as a backend, the files need not exist in memory at any point.
+
+Of course some combination of both these approaches will be useful in many cases.

--- a/pkg/nf90io/nf90io_init_file.F
+++ b/pkg/nf90io/nf90io_init_file.F
@@ -12,13 +12,15 @@ C     !INTERFACE:
         use netcdf
         IMPLICIT NONE
 
-#include "mpif.h"
 #include "SIZE.h"
 #include "BUILD_INFO.h"
 #include "EEPARAMS.h"
+#include "EESUPPORT.h"
+C #include "mpif.h"  EESupport already includes this
 C #include "NF90IO.h"
 #include "PARAMS.h"
 #include "GRID.h"
+#include "NF90IO.h"
 #include "DYNVARS.h"
 #ifdef ALLOW_NONHYDROSTATIC
 #include "NH_VARS.h"
@@ -41,10 +43,17 @@ C #include "NF90IO.h"
 
 C initialize this new file...
         mode_flag = IOR(nf90_netcdf4, nf90_classic_model)
-        mode_flag = IOR(mode_flag, nf90_mpiio)
-        err = nf90_create(ncfilename, mode_flag, ncid, comm =
-     $       MPI_COMM_WORLD,info = MPI_INFO_NULL)
-        CALL nf90ERR(err,"Opening netcdf file",myThid)
+        IF (usingMPI) THEN
+#ifdef ALLOW_USE_MPI
+              mode_flag = IOR(mode_flag, nf90_mpiio)
+              err = nf90_create(ncfilename, mode_flag, ncid, comm =
+     $             MPI_COMM_WORLD,info = MPI_INFO_NULL)
+              CALL nf90ERR(err,"Opening netcdf file w/ MPI",myThid)
+#endif
+        ELSE
+          err = nf90_create(ncfilename, mode_flag, ncid)
+          CALL nf90ERR(err,"Opening netcdf file non-MPI",myThid)
+        ENDIF
 C Set the dimensions...
 C record is my unlimited.  Other mitgcms seem to use time...
         err = nf90_def_dim(ncid, "record", nf90_unlimited, rec_dimid)
@@ -70,43 +79,43 @@ C Define co-ordinate variables (i.e. data that goes w/ each dimension)
         err = nf90_def_var(ncid, "record", NF90_INT, (/ rec_dimid /),
      $       varid)
         CALL nf90ERR(err,"Adding record variable",myThid)
-        err = nf90_put_att(ncid, varid, 
-     $       "standard_name", 
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name",
      $       "")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "Sequential record number")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "")
         CALL nf90ERR(err,"Setting attributes",myThid)
-        
+
         err = nf90_def_var(ncid, "i", NF90_INT, (/ i_dimid /), varid)
         CALL nf90ERR(err,"Adding i variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "x_grid_index")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "x-dimension of the t grid")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "")
         CALL nf90ERR(err,"Setting attributes",myThid)
-        
+
         err = nf90_def_var(ncid, "i_g", NF90_INT, (/ ig_dimid /),
      $       varid)
         CALL nf90ERR(err,"Adding i_g variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "x_grid_index_at_u_location")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "x-dimension of the u grid")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "c_grid_axis_shift",
      $       -0.5)
         CALL nf90ERR(err,"Setting attributes",myThid)
@@ -114,12 +123,12 @@ C Define co-ordinate variables (i.e. data that goes w/ each dimension)
         err = nf90_def_var(ncid, "j", NF90_INT, (/ j_dimid /), varid)
         CALL nf90ERR(err,"Adding j variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "y_grid_index_at_t_location")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "y-dimension of the t grid")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "")
         CALL nf90ERR(err,"Setting attributes",myThid)
@@ -128,27 +137,27 @@ C Define co-ordinate variables (i.e. data that goes w/ each dimension)
      $       varid)
         CALL nf90ERR(err,"Adding j_g variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "y_grid_index_at_v_location")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "y-dimension of the v grid")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "c_grid_axis_shift",
      $       -0.5)
 
         err = nf90_def_var(ncid, "k", NF90_INT, (/ k_dimid /), varid)
         CALL nf90ERR(err,"Adding k variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "z_grid_index")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "z-dimension of the t grid")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "")
 
@@ -158,15 +167,15 @@ C Define co-ordinate variables (i.e. data that goes w/ each dimension)
      $       varid)
         CALL nf90ERR(err,"Adding k_l variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "z_grid_index_at_upper_w_location")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "z-dimension of the w grid")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "c_grid_axis_shift",
      $       0.5)
 
@@ -175,15 +184,15 @@ C Define co-ordinate variables (i.e. data that goes w/ each dimension)
      $       varid)
         CALL nf90ERR(err,"Adding k_u variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "z_grid_index_at_lower_w_location")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "z-dimension of the w grid")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "c_grid_axis_shift",
      $       -0.5)
 
@@ -192,15 +201,15 @@ C Define co-ordinate variables (i.e. data that goes w/ each dimension)
      $       varid)
         CALL nf90ERR(err,"Adding k_p1 variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "z_grid_index_at_w_location")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "z-dimension of the w grid")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "c_grid_axis_shift",
      $       (/ -0.5, 0.5/))
 
@@ -209,9 +218,9 @@ C     record-like variables...
      $       varid)
         CALL nf90ERR(err,"Adding iter variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "timestep")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "model timestep number")
 
@@ -219,19 +228,19 @@ C     record-like variables...
      $       varid)
         CALL nf90ERR(err,"Adding iter variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "time")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "Time")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "seconds")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "axis",
      $       "T")
 C     NOT SURE IF THIS IS A VARIABLE?
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "calendar",
      $       "gregorian")
 
@@ -240,15 +249,15 @@ C     Water depth
      $       j_dimid /),varid)
         CALL nf90ERR(err,"Adding Depth variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "ocean_depth")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "ocean depth")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "m")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "coordinate",
      $       "XC YC")
 
@@ -258,15 +267,15 @@ C     Do the grid variables...
      $       j_dimid /),varid)
         CALL nf90ERR(err,"Adding XC variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "plane_x_coordinate")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "x coordinate")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "m")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "coordinate",
      $       "YC XC")
 
@@ -274,15 +283,15 @@ C     Do the grid variables...
      $       jg_dimid /),varid)
         CALL nf90ERR(err,"Adding XG variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "plane_x_coordinate_at_f_location")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "x coordinate")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "m")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "coordinate",
      $       "YG XG")
 
@@ -290,15 +299,15 @@ C     Do the grid variables...
      $       j_dimid /),varid)
         CALL nf90ERR(err,"Adding YC variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "plane_y_coordinate")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "y coordinate")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "m")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "coordinate",
      $       "YC XC")
 
@@ -306,15 +315,15 @@ C     Do the grid variables...
      $       jg_dimid /),varid)
         CALL nf90ERR(err,"Adding YG variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "plane_y_coordinate_at_f_location")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "y coordinate")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "m")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "coordinate",
      $       "YG XG")
 
@@ -323,18 +332,18 @@ C     Do the grid variables...
      $       ,varid)
         CALL nf90ERR(err,"Adding Z variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "depth")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "vertical coordinate of cell center")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "m")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "positive",
      $       "down")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "coordinate",
      $       "Z")
 
@@ -342,15 +351,15 @@ C     Do the grid variables...
      $       ,varid)
         CALL nf90ERR(err,"Adding Zu variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "depth_at_lower_w_location")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "vertical coordinate of lower cell interface")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "m")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "positive",
      $       "down")
 
@@ -358,15 +367,15 @@ C     Do the grid variables...
      $       ,varid)
         CALL nf90ERR(err,"Adding Zl variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "depth_at_upper_w_location")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "vertical coordinate of upper cell interface")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "m")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "positive",
      $       "down")
 
@@ -374,15 +383,15 @@ C     Do the grid variables...
      $       ,varid)
         CALL nf90ERR(err,"Adding Zp1 variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "depth_at_w_location")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "vertical coordinate of cell interface")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "m")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "positive",
      $       "down")
 
@@ -392,15 +401,15 @@ C     rAs Areas
      $       j_dimid /),varid)
         CALL nf90ERR(err,"Adding rA variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "cell_area")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "cell area")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "m2")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "coordinates",
      $       "YC XC")
 
@@ -408,15 +417,15 @@ C     rAs Areas
      $       j_dimid /),varid)
         CALL nf90ERR(err,"Adding rAw variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "cell_area_at_u_location")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "cell area")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "m2")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "coordinates",
      $       "YC XG")
 
@@ -424,15 +433,15 @@ C     rAs Areas
      $       jg_dimid /),varid)
         CALL nf90ERR(err,"Adding rAs variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "cell_area_at_v_location")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "cell area")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "m2")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "coordinates",
      $       "YG XC")
 
@@ -440,15 +449,15 @@ C     rAs Areas
      $       jg_dimid /),varid)
         CALL nf90ERR(err,"Adding rAz variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "cell_area_at_f_location")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "cell area")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "m2")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "coordinates",
      $       "YG XG")
 
@@ -457,15 +466,15 @@ C     dx dy:
      $       jg_dimid /),varid)
         CALL nf90ERR(err,"Adding dxG variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "cell_x_size_at_v_location")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "cell x size")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "m")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "coordinates",
      $       "YG XC")
 
@@ -473,15 +482,15 @@ C     dx dy:
      $       j_dimid /),varid)
         CALL nf90ERR(err,"Adding dyG variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "cell_y_size_at_u_location")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "cell y size")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "m")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "coordinates",
      $       "YC XG")
 
@@ -489,15 +498,15 @@ C     dx dy:
      $       j_dimid /),varid)
         CALL nf90ERR(err,"Adding dxC variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "cell_x_size_at_u_location")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "cell y size")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "m")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "coordinates",
      $       "YC XG")
 
@@ -505,15 +514,15 @@ C     dx dy:
      $       jg_dimid /),varid)
         CALL nf90ERR(err,"Adding dyC variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "cell_y_size_at_v_location")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "cell y size")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "m")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "coordinates",
      $       "YG XC")
 
@@ -522,12 +531,12 @@ C     drs
      $       ,varid)
         CALL nf90ERR(err,"Adding drC variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "cell_z_size_at_w_location")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "cell z size")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "m")
 
@@ -535,12 +544,12 @@ C     drs
      $       ,varid)
         CALL nf90ERR(err,"Adding drF variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "cell_z_size")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "cell z size")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "m")
 
@@ -549,9 +558,9 @@ C     hFacs:
      $       j_dimid, k_dimid/),varid)
         CALL nf90ERR(err,"Adding hFacC variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "cell_vertical_fraction")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "vertical fraction of open cell")
 
@@ -559,9 +568,9 @@ C     hFacs:
      $       j_dimid, k_dimid/),varid)
         CALL nf90ERR(err,"Adding hFacW variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "cell_vertical_fraction_at_u_location")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "vertical fraction of open cell")
 
@@ -569,9 +578,9 @@ C     hFacs:
      $       jg_dimid, k_dimid/),varid)
         CALL nf90ERR(err,"Adding hFacS variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "cell_vertical_fraction_at_v_location")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "vertical fraction of open cell")
 
@@ -581,12 +590,12 @@ C     Define pHrefs
      $       ,varid)
         CALL nf90ERR(err,"Adding PHrefC variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "cell_reference_pressure")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "Reference Hydrostatif Pressure")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "m2 s-2")
 
@@ -594,12 +603,12 @@ C     Define pHrefs
      $       ,varid)
         CALL nf90ERR(err,"Adding PHrefF variable",myThid)
         err = nf90_put_att(ncid, varid,
-     $       "standard_name", 
+     $       "standard_name",
      $       "cell_reference_pressure")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "long_name",
      $       "Reference Hydrostatif Pressure")
-        err = nf90_put_att(ncid, varid, 
+        err = nf90_put_att(ncid, varid,
      $       "units",
      $       "m2 s-2")
 
@@ -610,7 +619,7 @@ C     Stop defining stuff and start filling
 C     co-ordinate k:
         err = nf90_inq_varid(ncid, "k", varid)
         CALL nf90ERR(err, "Getting k varid",myThid)
-        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90io_var_par_access(ncid, varid)
         CALL nf90ERR(err, "Setting k variable to par access",myThid)
         ks(1:Nr) = (/  (I, I = 0, Nr-1)  /)
         err = nf90_put_var(ncid, varid, kS(1:Nr),
@@ -620,7 +629,7 @@ C     co-ordinate k:
 C     co-ordinate i:
         err = nf90_inq_varid(ncid, "i", varid)
         CALL nf90ERR(err, "Getting i varid",myThid)
-        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90io_var_par_access(ncid, varid)
         CALL nf90ERR(err, "Setting i variable to par access",myThid)
         do bj = 1,nSy
            do bi = 1,nSx
@@ -639,7 +648,7 @@ C     maybe incorrect.
 C     co-ordinate i_g:
         err = nf90_inq_varid(ncid, "i_g", varid)
         CALL nf90ERR(err, "Getting i_g varid",myThid)
-        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90io_var_par_access(ncid, varid)
         CALL nf90ERR(err, "Setting i_g variable to par access",myThid)
         do bj = 1,nSy
            do bi = 1,nSx
@@ -658,7 +667,7 @@ C     maybe incorrect.
 C     co-ordinate j:
         err = nf90_inq_varid(ncid, "j", varid)
         CALL nf90ERR(err, "Getting j varid",myThid)
-        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90io_var_par_access(ncid, varid)
         CALL nf90ERR(err, "Setting j variable to par access",myThid)
 
         do bj = 1,nSy
@@ -678,9 +687,9 @@ C     maybe incorrect.
 C     co-ordinate j:
         err = nf90_inq_varid(ncid, "j_g", varid)
         CALL nf90ERR(err, "Getting j_g varid",myThid)
-        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90io_var_par_access(ncid, varid)
         CALL nf90ERR(err, "Setting j_g variable to par access",myThid)
-        
+
         do bj = 1,nSy
            do bi = 1,nSx
 C     NOT tested w/ more than one thread be processor, so
@@ -706,7 +715,7 @@ C     co-ordinate ks:
               err = nf90_inq_varid(ncid, "k_l", varid)
            endif
            CALL nf90ERR(err, "Getting k varid",myThid)
-           err = nf90_var_par_access(ncid, varid, nf90_collective)
+           err = nf90io_var_par_access(ncid, varid)
            CALL nf90ERR(err, "Setting k variable to par access"
      $          ,myThid)
 
@@ -721,7 +730,7 @@ C     co-ordinate ks:
 C     co-ordinate k+:
         err = nf90_inq_varid(ncid, "k_p1", varid)
         CALL nf90ERR(err, "Getting k_p1 varid",myThid)
-        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90io_var_par_access(ncid, varid)
         CALL nf90ERR(err, "Setting k_p1 variable to par access"
      $       ,myThid)
         ks(1:Nr+1) = (/  (I, I = 0,Nr)  /)
@@ -737,7 +746,7 @@ C     Now fill the grid data from variables...
 C     z-s
         err = nf90_inq_varid(ncid, "Z", varid)
         CALL nf90ERR(err, "Getting Z varid",myThid)
-        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90io_var_par_access(ncid, varid)
         err = nf90_put_var(ncid, varid,
      &       rC,
      &       start = (/ 1 /) ,
@@ -745,7 +754,7 @@ C     z-s
 
         err = nf90_inq_varid(ncid, "Zp1", varid)
         CALL nf90ERR(err, "Getting Zp1 varid",myThid)
-        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90io_var_par_access(ncid, varid)
         err = nf90_put_var(ncid, varid,
      &       rF,
      &       start = (/ 1 /) ,
@@ -753,7 +762,7 @@ C     z-s
 
         err = nf90_inq_varid(ncid, "Zu", varid)
         CALL nf90ERR(err, "Getting Zu varid",myThid)
-        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90io_var_par_access(ncid, varid)
         err = nf90_put_var(ncid, varid,
      &       rF(2:Nr+1),
      &       start = (/ 1 /) ,
@@ -761,7 +770,7 @@ C     z-s
 
         err = nf90_inq_varid(ncid, "drC", varid)
         CALL nf90ERR(err, "Getting drC varid",myThid)
-        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90io_var_par_access(ncid, varid)
         err = nf90_put_var(ncid, varid,
      &       drC(1:Nr+1),
      &       start = (/ 1 /) ,
@@ -770,7 +779,7 @@ C     z-s
 
         err = nf90_inq_varid(ncid, "drF", varid)
         CALL nf90ERR(err, "Getting drF varid",myThid)
-        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90io_var_par_access(ncid, varid)
         err = nf90_put_var(ncid, varid,
      &       drF(1:Nr),
      &       start = (/ 1 /) ,
@@ -780,7 +789,7 @@ C     z-s
 
         err = nf90_inq_varid(ncid, "Zl", varid)
         CALL nf90ERR(err, "Getting Zl varid",myThid)
-        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90io_var_par_access(ncid, varid)
         err = nf90_put_var(ncid, varid,
      &       rF(1:Nr),
      &       start = (/ 1 /) ,
@@ -809,7 +818,7 @@ C     Hfacs
 C     Depth:  Special because model doesn't store
         err = nf90_inq_varid(ncid, "Depth", varid)
         CALL nf90ERR(err, "Getting varid Depth",myThid)
-        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90io_var_par_access(ncid, varid)
         count(1:2) = (/  sNx, sNy /)
         do bj = 1,nSy
            do bi = 1,nSx
@@ -818,7 +827,7 @@ C     maybe incorrect.
               start(1:2) = (/ myXGlobalLo+(bi-1)*sNx,
      &             myYGlobalLo+(bj-1)*sNy /)
               err = nf90_put_var(ncid, varid,
-     &             Ro_surf(1:sNx, 1:sNy,bi,bj) - 
+     &             Ro_surf(1:sNx, 1:sNy,bi,bj) -
      &             R_low(1:sNx, 1:sNy,bi,bj),
      &             start = start(1:2), count = count(1:2))
               CALL nf90ERR(err, "Putting Depth into file", myThid)
@@ -832,18 +841,18 @@ C     Reference densities...
         ENDDO
         err = nf90_inq_varid(ncid, "PHrefF", varid)
         CALL nf90ERR(err, "Getting PHRefF varid",myThid)
-        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90io_var_par_access(ncid, varid)
         err = nf90_put_var(ncid, varid,
      &       ks(1:NR+1),
      &       start = (/ 1 /) ,
      &       count = (/ Nr+1 /) )
-        
+
         DO k=1,Nr
            ks(k) = phiRef(2*k)
         ENDDO
         err = nf90_inq_varid(ncid, "PHrefC", varid)
         CALL nf90ERR(err, "Getting PHRefC varid",myThid)
-        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90io_var_par_access(ncid, varid)
         err = nf90_put_var(ncid, varid,
      &       ks(1:NR),
      &       start = (/ 1 /) ,
@@ -855,7 +864,7 @@ C     Set file attributes
         err = nf90_redef(ncid)
         CALL nf90ERR(err, "Entering Def mode for file attributes"
      $       ,myThid)
-        
+
         err = nf90_put_att(ncid, NF90_GLOBAL, 'the_run_name',
      $       the_run_name)
 
@@ -870,11 +879,11 @@ C     Set file attributes
      &       THISUSER)
 #endif
 #ifdef THISHOST
-        err = nf90_put_att( ncid, NF90_GLOBAL, 'build_host', 
+        err = nf90_put_att( ncid, NF90_GLOBAL, 'build_host',
      &       THISHOST)
 #endif
 #ifdef THISDATE
-        err = nf90_put_att( ncid, NF90_GLOBAL, 'build_date', 
+        err = nf90_put_att( ncid, NF90_GLOBAL, 'build_date',
      &       THISDATE)
 #endif
 
@@ -887,11 +896,11 @@ C     Set file attributes
         err = nf90_enddef(ncid)
         CALL nf90ERR(err, "Ending def mode file attributes",myThid)
 
-        
+
 CCCCCCCCCCCCCCCCCC
 C     Close
         err = nf90_close(ncid)
         CALL nf90ERR(err, "Closing after setting up grids",myThid)
-        
+
         RETURN
         END

--- a/pkg/nf90io/nf90io_init_file.F
+++ b/pkg/nf90io/nf90io_init_file.F
@@ -1,0 +1,897 @@
+
+#include "PACKAGES_CONFIG.h"
+#include "CPP_OPTIONS.h"
+
+#undef  MULTIPLE_RECORD_STATE_FILES
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+CBOP
+
+C     !INTERFACE:
+      SUBROUTINE NF90IO_INIT_FILE ( ncfilename, myThid )
+        use netcdf
+        IMPLICIT NONE
+
+#include "mpif.h"
+#include "SIZE.h"
+#include "BUILD_INFO.h"
+#include "EEPARAMS.h"
+C #include "NF90IO.h"
+#include "PARAMS.h"
+#include "GRID.h"
+#include "DYNVARS.h"
+#ifdef ALLOW_NONHYDROSTATIC
+#include "NH_VARS.h"
+#endif
+
+        INTEGER myThid
+        character*(MAX_LEN_FNAM) ncfilename
+
+        INTEGER mode_flag, ncid, err, i, j, k, t
+        INTEGER bi, bj
+        INTEGER i_dimid, j_dimid, k_dimid, dimids(4), varid
+        INTEGER ig_dimid, jg_dimid, kl_dimid, ku_dimid, kp1_dimid
+        INTEGER start(4), count(4), rec_dimid
+        LOGICAL iAmDoingIO
+        character*(MAX_LEN_MBUF) msgbuf
+        _RL     a(sNx,sNy,Nr)
+        _RL     is(sNx+10)
+        _RL     js(sNy+10)
+        _RL     ks(Nr+10)
+
+C initialize this new file...
+        mode_flag = IOR(nf90_netcdf4, nf90_classic_model)
+        mode_flag = IOR(mode_flag, nf90_mpiio)
+        err = nf90_create(ncfilename, mode_flag, ncid, comm =
+     $       MPI_COMM_WORLD,info = MPI_INFO_NULL)
+        CALL nf90ERR(err,"Opening netcdf file",myThid)
+C Set the dimensions...
+C record is my unlimited.  Other mitgcms seem to use time...
+        err = nf90_def_dim(ncid, "record", nf90_unlimited, rec_dimid)
+        CALL nf90ERR(err,"Adding record dim",myThid)
+        err = nf90_def_dim(ncid, "i", nSx*sNx*nPx , i_dimid)
+        CALL nf90ERR(err,"Adding i dim",myThid)
+        err = nf90_def_dim(ncid, "i_g", nSx*sNx*nPx , ig_dimid)
+        CALL nf90ERR(err,"Adding i_g dim",myThid)
+        err = nf90_def_dim(ncid, "j", nSy*sNy*nPy , j_dimid)
+        CALL nf90ERR(err,"Adding j dim",myThid)
+        err = nf90_def_dim(ncid, "j_g", nSy*sNy*nPy , jg_dimid)
+        CALL nf90ERR(err,"Adding j_g dim",myThid)
+        err = nf90_def_dim(ncid, "k", Nr, k_dimid)
+        CALL nf90ERR(err,"Adding k dim",myThid)
+        err = nf90_def_dim(ncid, "k_l", Nr, kl_dimid)
+        CALL nf90ERR(err,"Adding k_l dim",myThid)
+        err = nf90_def_dim(ncid, "k_u", Nr, ku_dimid)
+        CALL nf90ERR(err,"Adding k_u dim",myThid)
+        err = nf90_def_dim(ncid, "k_p1", Nr+1, kp1_dimid)
+        CALL nf90ERR(err,"Adding k_p1 dim",myThid)
+
+C Define co-ordinate variables (i.e. data that goes w/ each dimension)
+        err = nf90_def_var(ncid, "record", NF90_INT, (/ rec_dimid /),
+     $       varid)
+        CALL nf90ERR(err,"Adding record variable",myThid)
+        err = nf90_put_att(ncid, varid, 
+     $       "standard_name", 
+     $       "")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "Sequential record number")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "")
+        CALL nf90ERR(err,"Setting attributes",myThid)
+        
+        err = nf90_def_var(ncid, "i", NF90_INT, (/ i_dimid /), varid)
+        CALL nf90ERR(err,"Adding i variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "x_grid_index")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "x-dimension of the t grid")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "")
+        CALL nf90ERR(err,"Setting attributes",myThid)
+        
+        err = nf90_def_var(ncid, "i_g", NF90_INT, (/ ig_dimid /),
+     $       varid)
+        CALL nf90ERR(err,"Adding i_g variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "x_grid_index_at_u_location")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "x-dimension of the u grid")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "")
+        err = nf90_put_att(ncid, varid, 
+     $       "c_grid_axis_shift",
+     $       -0.5)
+        CALL nf90ERR(err,"Setting attributes",myThid)
+
+        err = nf90_def_var(ncid, "j", NF90_INT, (/ j_dimid /), varid)
+        CALL nf90ERR(err,"Adding j variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "y_grid_index_at_t_location")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "y-dimension of the t grid")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "")
+        CALL nf90ERR(err,"Setting attributes",myThid)
+
+        err = nf90_def_var(ncid, "j_g", NF90_INT, (/ jg_dimid /),
+     $       varid)
+        CALL nf90ERR(err,"Adding j_g variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "y_grid_index_at_v_location")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "y-dimension of the v grid")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "")
+        err = nf90_put_att(ncid, varid, 
+     $       "c_grid_axis_shift",
+     $       -0.5)
+
+        err = nf90_def_var(ncid, "k", NF90_INT, (/ k_dimid /), varid)
+        CALL nf90ERR(err,"Adding k variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "z_grid_index")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "z-dimension of the t grid")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "")
+
+
+
+        err = nf90_def_var(ncid, "k_l", NF90_INT, (/ kl_dimid /),
+     $       varid)
+        CALL nf90ERR(err,"Adding k_l variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "z_grid_index_at_upper_w_location")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "z-dimension of the w grid")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "")
+        err = nf90_put_att(ncid, varid, 
+     $       "c_grid_axis_shift",
+     $       0.5)
+
+
+        err = nf90_def_var(ncid, "k_u", NF90_INT, (/ ku_dimid /),
+     $       varid)
+        CALL nf90ERR(err,"Adding k_u variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "z_grid_index_at_lower_w_location")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "z-dimension of the w grid")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "")
+        err = nf90_put_att(ncid, varid, 
+     $       "c_grid_axis_shift",
+     $       -0.5)
+
+
+        err = nf90_def_var(ncid, "k_p1", NF90_INT, (/ kp1_dimid /),
+     $       varid)
+        CALL nf90ERR(err,"Adding k_p1 variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "z_grid_index_at_w_location")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "z-dimension of the w grid")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "")
+        err = nf90_put_att(ncid, varid, 
+     $       "c_grid_axis_shift",
+     $       (/ -0.5, 0.5/))
+
+C     record-like variables...
+        err = nf90_def_var(ncid, "iter", NF90_INT, (/ rec_dimid /),
+     $       varid)
+        CALL nf90ERR(err,"Adding iter variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "timestep")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "model timestep number")
+
+        err = nf90_def_var(ncid, "time", NF90_DOUBLE, (/ rec_dimid /),
+     $       varid)
+        CALL nf90ERR(err,"Adding iter variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "time")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "Time")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "seconds")
+        err = nf90_put_att(ncid, varid, 
+     $       "axis",
+     $       "T")
+C     NOT SURE IF THIS IS A VARIABLE?
+        err = nf90_put_att(ncid, varid, 
+     $       "calendar",
+     $       "gregorian")
+
+C     Water depth
+        err = nf90_def_var(ncid, "Depth", NF90_DOUBLE, (/ i_dimid,
+     $       j_dimid /),varid)
+        CALL nf90ERR(err,"Adding Depth variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "ocean_depth")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "ocean depth")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "m")
+        err = nf90_put_att(ncid, varid, 
+     $       "coordinate",
+     $       "XC YC")
+
+
+C     Do the grid variables...
+        err = nf90_def_var(ncid, "XC", NF90_DOUBLE, (/ i_dimid,
+     $       j_dimid /),varid)
+        CALL nf90ERR(err,"Adding XC variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "plane_x_coordinate")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "x coordinate")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "m")
+        err = nf90_put_att(ncid, varid, 
+     $       "coordinate",
+     $       "YC XC")
+
+        err = nf90_def_var(ncid, "XG", NF90_DOUBLE, (/ ig_dimid,
+     $       jg_dimid /),varid)
+        CALL nf90ERR(err,"Adding XG variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "plane_x_coordinate_at_f_location")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "x coordinate")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "m")
+        err = nf90_put_att(ncid, varid, 
+     $       "coordinate",
+     $       "YG XG")
+
+        err = nf90_def_var(ncid, "YC", NF90_DOUBLE, (/ i_dimid,
+     $       j_dimid /),varid)
+        CALL nf90ERR(err,"Adding YC variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "plane_y_coordinate")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "y coordinate")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "m")
+        err = nf90_put_att(ncid, varid, 
+     $       "coordinate",
+     $       "YC XC")
+
+        err = nf90_def_var(ncid, "YG", NF90_DOUBLE, (/ ig_dimid,
+     $       jg_dimid /),varid)
+        CALL nf90ERR(err,"Adding YG variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "plane_y_coordinate_at_f_location")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "y coordinate")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "m")
+        err = nf90_put_att(ncid, varid, 
+     $       "coordinate",
+     $       "YG XG")
+
+
+        err = nf90_def_var(ncid, "Z", NF90_DOUBLE, (/ k_dimid /)
+     $       ,varid)
+        CALL nf90ERR(err,"Adding Z variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "depth")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "vertical coordinate of cell center")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "m")
+        err = nf90_put_att(ncid, varid, 
+     $       "positive",
+     $       "down")
+        err = nf90_put_att(ncid, varid, 
+     $       "coordinate",
+     $       "Z")
+
+        err = nf90_def_var(ncid, "Zu", NF90_DOUBLE, (/ ku_dimid /)
+     $       ,varid)
+        CALL nf90ERR(err,"Adding Zu variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "depth_at_lower_w_location")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "vertical coordinate of lower cell interface")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "m")
+        err = nf90_put_att(ncid, varid, 
+     $       "positive",
+     $       "down")
+
+        err = nf90_def_var(ncid, "Zl", NF90_DOUBLE, (/ kl_dimid /)
+     $       ,varid)
+        CALL nf90ERR(err,"Adding Zl variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "depth_at_upper_w_location")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "vertical coordinate of upper cell interface")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "m")
+        err = nf90_put_att(ncid, varid, 
+     $       "positive",
+     $       "down")
+
+        err = nf90_def_var(ncid, "Zp1", NF90_DOUBLE, (/ kp1_dimid /)
+     $       ,varid)
+        CALL nf90ERR(err,"Adding Zp1 variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "depth_at_w_location")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "vertical coordinate of cell interface")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "m")
+        err = nf90_put_att(ncid, varid, 
+     $       "positive",
+     $       "down")
+
+C     rAs Areas
+
+        err = nf90_def_var(ncid, "rA", NF90_DOUBLE, (/ i_dimid,
+     $       j_dimid /),varid)
+        CALL nf90ERR(err,"Adding rA variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "cell_area")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "cell area")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "m2")
+        err = nf90_put_att(ncid, varid, 
+     $       "coordinates",
+     $       "YC XC")
+
+        err = nf90_def_var(ncid, "rAw", NF90_DOUBLE, (/ ig_dimid,
+     $       j_dimid /),varid)
+        CALL nf90ERR(err,"Adding rAw variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "cell_area_at_u_location")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "cell area")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "m2")
+        err = nf90_put_att(ncid, varid, 
+     $       "coordinates",
+     $       "YC XG")
+
+        err = nf90_def_var(ncid, "rAs", NF90_DOUBLE, (/ i_dimid,
+     $       jg_dimid /),varid)
+        CALL nf90ERR(err,"Adding rAs variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "cell_area_at_v_location")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "cell area")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "m2")
+        err = nf90_put_att(ncid, varid, 
+     $       "coordinates",
+     $       "YG XC")
+
+        err = nf90_def_var(ncid, "rAz", NF90_DOUBLE, (/ ig_dimid,
+     $       jg_dimid /),varid)
+        CALL nf90ERR(err,"Adding rAz variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "cell_area_at_f_location")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "cell area")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "m2")
+        err = nf90_put_att(ncid, varid, 
+     $       "coordinates",
+     $       "YG XG")
+
+C     dx dy:
+        err = nf90_def_var(ncid, "dxG", NF90_DOUBLE, (/ i_dimid,
+     $       jg_dimid /),varid)
+        CALL nf90ERR(err,"Adding dxG variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "cell_x_size_at_v_location")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "cell x size")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "m")
+        err = nf90_put_att(ncid, varid, 
+     $       "coordinates",
+     $       "YG XC")
+
+        err = nf90_def_var(ncid, "dyG", NF90_DOUBLE, (/ ig_dimid,
+     $       j_dimid /),varid)
+        CALL nf90ERR(err,"Adding dyG variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "cell_y_size_at_u_location")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "cell y size")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "m")
+        err = nf90_put_att(ncid, varid, 
+     $       "coordinates",
+     $       "YC XG")
+
+        err = nf90_def_var(ncid, "dxC", NF90_DOUBLE, (/ ig_dimid,
+     $       j_dimid /),varid)
+        CALL nf90ERR(err,"Adding dxC variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "cell_x_size_at_u_location")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "cell y size")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "m")
+        err = nf90_put_att(ncid, varid, 
+     $       "coordinates",
+     $       "YC XG")
+
+        err = nf90_def_var(ncid, "dyC", NF90_DOUBLE, (/ i_dimid,
+     $       jg_dimid /),varid)
+        CALL nf90ERR(err,"Adding dyC variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "cell_y_size_at_v_location")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "cell y size")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "m")
+        err = nf90_put_att(ncid, varid, 
+     $       "coordinates",
+     $       "YG XC")
+
+C     drs
+        err = nf90_def_var(ncid, "drC", NF90_DOUBLE, (/ kp1_dimid /)
+     $       ,varid)
+        CALL nf90ERR(err,"Adding drC variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "cell_z_size_at_w_location")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "cell z size")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "m")
+
+        err = nf90_def_var(ncid, "drF", NF90_DOUBLE, (/ k_dimid /)
+     $       ,varid)
+        CALL nf90ERR(err,"Adding drF variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "cell_z_size")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "cell z size")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "m")
+
+C     hFacs:
+        err = nf90_def_var(ncid, "hFacC", NF90_DOUBLE, (/ i_dimid,
+     $       j_dimid, k_dimid/),varid)
+        CALL nf90ERR(err,"Adding hFacC variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "cell_vertical_fraction")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "vertical fraction of open cell")
+
+        err = nf90_def_var(ncid, "hFacW", NF90_DOUBLE, (/ ig_dimid,
+     $       j_dimid, k_dimid/),varid)
+        CALL nf90ERR(err,"Adding hFacW variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "cell_vertical_fraction_at_u_location")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "vertical fraction of open cell")
+
+        err = nf90_def_var(ncid, "hFacS", NF90_DOUBLE, (/ i_dimid,
+     $       jg_dimid, k_dimid/),varid)
+        CALL nf90ERR(err,"Adding hFacS variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "cell_vertical_fraction_at_v_location")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "vertical fraction of open cell")
+
+C     Define pHrefs
+
+        err = nf90_def_var(ncid, "PHrefC", NF90_DOUBLE, (/ k_dimid/)
+     $       ,varid)
+        CALL nf90ERR(err,"Adding PHrefC variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "cell_reference_pressure")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "Reference Hydrostatif Pressure")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "m2 s-2")
+
+        err = nf90_def_var(ncid, "PHrefF", NF90_DOUBLE, (/ kp1_dimid/)
+     $       ,varid)
+        CALL nf90ERR(err,"Adding PHrefF variable",myThid)
+        err = nf90_put_att(ncid, varid,
+     $       "standard_name", 
+     $       "cell_reference_pressure")
+        err = nf90_put_att(ncid, varid, 
+     $       "long_name",
+     $       "Reference Hydrostatif Pressure")
+        err = nf90_put_att(ncid, varid, 
+     $       "units",
+     $       "m2 s-2")
+
+
+C     Stop defining stuff and start filling
+        err = nf90_enddef(ncid)
+
+C     co-ordinate k:
+        err = nf90_inq_varid(ncid, "k", varid)
+        CALL nf90ERR(err, "Getting k varid",myThid)
+        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        CALL nf90ERR(err, "Setting k variable to par access",myThid)
+        ks(1:Nr) = (/  (I, I = 0, Nr-1)  /)
+        err = nf90_put_var(ncid, varid, kS(1:Nr),
+     $       start = (/ 1 /) , count = (/ Nr /) )
+        CALL nf90ERR(err, "Setting k variable values",myThid)
+
+C     co-ordinate i:
+        err = nf90_inq_varid(ncid, "i", varid)
+        CALL nf90ERR(err, "Getting i varid",myThid)
+        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        CALL nf90ERR(err, "Setting i variable to par access",myThid)
+        do bj = 1,nSy
+           do bi = 1,nSx
+C     NOT tested w/ more than one thread be processor, so
+C     maybe incorrect.
+              is(1:sNx) = (/  (I, I = myXGlobalLo+(bi-1)*sNx-1,
+     $             myXGlobalLo+(bi)*sNx-1)  /)
+              err = nf90_put_var(ncid, varid,
+     &             is(1:sNx),
+     &             start = (/ myXGlobalLo+(bi-1)*sNx /) ,
+     &             count = (/ sNx/) )
+              CALL nf90ERR(err, "Getting i varid",myThid)
+           enddo
+        enddo
+
+C     co-ordinate i_g:
+        err = nf90_inq_varid(ncid, "i_g", varid)
+        CALL nf90ERR(err, "Getting i_g varid",myThid)
+        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        CALL nf90ERR(err, "Setting i_g variable to par access",myThid)
+        do bj = 1,nSy
+           do bi = 1,nSx
+C     NOT tested w/ more than one thread be processor, so
+C     maybe incorrect.
+              is(1:sNx) = (/  (I, I = myXGlobalLo+(bi-1)*sNx-1,
+     $             myXGlobalLo+(bi)*sNx-1)  /)
+              err = nf90_put_var(ncid, varid,
+     &             is(1:sNx),
+     &             start = (/ myXGlobalLo+(bi-1)*sNx /) ,
+     &             count = (/ sNx/) )
+              CALL nf90ERR(err, "Getting i_g varid",myThid)
+           enddo
+        enddo
+
+C     co-ordinate j:
+        err = nf90_inq_varid(ncid, "j", varid)
+        CALL nf90ERR(err, "Getting j varid",myThid)
+        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        CALL nf90ERR(err, "Setting j variable to par access",myThid)
+
+        do bj = 1,nSy
+           do bi = 1,nSx
+C     NOT tested w/ more than one thread be processor, so
+C     maybe incorrect.
+              js(1:sNy) = (/  (I, I = myYGlobalLo+(bj-1)*sNy-1,
+     &             myYGlobalLo+(bj)*sNy-1)  /)
+              err = nf90_put_var(ncid, varid,
+     &             js(1:sNy),
+     &             start = (/ myYGlobalLo+(bj-1)*sNy /) ,
+     &             count = (/ sNy/) )
+              CALL nf90ERR(err, "Getting j varid",myThid)
+           enddo
+        enddo
+
+C     co-ordinate j:
+        err = nf90_inq_varid(ncid, "j_g", varid)
+        CALL nf90ERR(err, "Getting j_g varid",myThid)
+        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        CALL nf90ERR(err, "Setting j_g variable to par access",myThid)
+        
+        do bj = 1,nSy
+           do bi = 1,nSx
+C     NOT tested w/ more than one thread be processor, so
+C     maybe incorrect.
+              js(1:sNy) = (/  (I, I = myYGlobalLo+(bj-1)*sNy-1,
+     &             myYGlobalLo+(bj)*sNy-1)  /)
+              err = nf90_put_var(ncid, varid,
+     &             js(1:sNy),
+     &             start = (/ myYGlobalLo+(bj-1)*sNy /) ,
+     &             count = (/ sNy/) )
+              CALL nf90ERR(err, "Putting j_g varid",myThid)
+           enddo
+        enddo
+
+
+C     co-ordinate ks:
+        do t = 1,3
+           if (t.EQ.1) then
+              err = nf90_inq_varid(ncid, "k", varid)
+           else if (t.EQ.2) then
+              err = nf90_inq_varid(ncid, "k_u", varid)
+           else if (t.EQ.3) then
+              err = nf90_inq_varid(ncid, "k_l", varid)
+           endif
+           CALL nf90ERR(err, "Getting k varid",myThid)
+           err = nf90_var_par_access(ncid, varid, nf90_collective)
+           CALL nf90ERR(err, "Setting k variable to par access"
+     $          ,myThid)
+
+           ks(1:Nr) = (/  (I, I = 0,Nr-1)  /)
+           err = nf90_put_var(ncid, varid,
+     &          ks(1:Nr),
+     &          start = (/ 1 /) ,
+     &          count = (/ Nr /) )
+           CALL nf90ERR(err, "Getting k varid",myThid)
+        enddo
+
+C     co-ordinate k+:
+        err = nf90_inq_varid(ncid, "k_p1", varid)
+        CALL nf90ERR(err, "Getting k_p1 varid",myThid)
+        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        CALL nf90ERR(err, "Setting k_p1 variable to par access"
+     $       ,myThid)
+        ks(1:Nr+1) = (/  (I, I = 0,Nr)  /)
+        err = nf90_put_var(ncid, varid,
+     &       ks(1:Nr+1),
+     &       start = (/ 1 /) ,
+     &       count = (/ Nr+1 /) )
+        CALL nf90ERR(err, "Writing k_p1",myThid)
+
+
+CCCCCCCCCCCCCC
+C     Now fill the grid data from variables...
+C     z-s
+        err = nf90_inq_varid(ncid, "Z", varid)
+        CALL nf90ERR(err, "Getting Z varid",myThid)
+        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90_put_var(ncid, varid,
+     &       rC,
+     &       start = (/ 1 /) ,
+     &       count = (/ Nr /) )
+
+        err = nf90_inq_varid(ncid, "Zp1", varid)
+        CALL nf90ERR(err, "Getting Zp1 varid",myThid)
+        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90_put_var(ncid, varid,
+     &       rF,
+     &       start = (/ 1 /) ,
+     &       count = (/ Nr+1 /) )
+
+        err = nf90_inq_varid(ncid, "Zu", varid)
+        CALL nf90ERR(err, "Getting Zu varid",myThid)
+        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90_put_var(ncid, varid,
+     &       rF(2:Nr+1),
+     &       start = (/ 1 /) ,
+     &       count = (/ Nr /) )
+
+        err = nf90_inq_varid(ncid, "drC", varid)
+        CALL nf90ERR(err, "Getting drC varid",myThid)
+        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90_put_var(ncid, varid,
+     &       drC(1:Nr+1),
+     &       start = (/ 1 /) ,
+     &       count = (/ Nr+1 /) )
+        CALL nf90ERR(err, "writing drC ",myThid)
+
+        err = nf90_inq_varid(ncid, "drF", varid)
+        CALL nf90ERR(err, "Getting drF varid",myThid)
+        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90_put_var(ncid, varid,
+     &       drF(1:Nr),
+     &       start = (/ 1 /) ,
+     &       count = (/ Nr /) )
+        CALL nf90ERR(err, "writing drF",myThid)
+
+
+        err = nf90_inq_varid(ncid, "Zl", varid)
+        CALL nf90ERR(err, "Getting Zl varid",myThid)
+        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90_put_var(ncid, varid,
+     &       rF(1:Nr),
+     &       start = (/ 1 /) ,
+     &       count = (/ Nr /) )
+
+C     Horizontal co-ordinates...
+
+        CALL NF90IO_FILL_2Dnorec(ncid, "XC", xC, myThid)
+        CALL NF90IO_FILL_2Dnorec(ncid, "XG", xG, myThid)
+        CALL NF90IO_FILL_2Dnorec(ncid, "YC", yC, myThid)
+        CALL NF90IO_FILL_2Dnorec(ncid, "YG", yG, myThid)
+        CALL NF90IO_FILL_2Dnorec(ncid, "dxC", dxC, myThid)
+        CALL NF90IO_FILL_2Dnorec(ncid, "dxG", dxG, myThid)
+        CALL NF90IO_FILL_2Dnorec(ncid, "dyC", dxC, myThid)
+        CALL NF90IO_FILL_2Dnorec(ncid, "dyG", dxG, myThid)
+        CALL NF90IO_FILL_2Dnorec(ncid, "rA", rA, myThid)
+        CALL NF90IO_FILL_2Dnorec(ncid, "rAz", rAz, myThid)
+        CALL NF90IO_FILL_2Dnorec(ncid, "rAw", rAw, myThid)
+        CALL NF90IO_FILL_2Dnorec(ncid, "rAs", rAs, myThid)
+
+C     Hfacs
+        CALL NF90IO_FILL_3Dnorec(ncid, "hFacC", hFacC, myThid)
+        CALL NF90IO_FILL_3Dnorec(ncid, "hFacW", hFacW, myThid)
+        CALL NF90IO_FILL_3Dnorec(ncid, "hFacS", hFacS, myThid)
+
+C     Depth:  Special because model doesn't store
+        err = nf90_inq_varid(ncid, "Depth", varid)
+        CALL nf90ERR(err, "Getting varid Depth",myThid)
+        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        count(1:2) = (/  sNx, sNy /)
+        do bj = 1,nSy
+           do bi = 1,nSx
+C     NOT tested w/ more than one thread be processor, so
+C     maybe incorrect.
+              start(1:2) = (/ myXGlobalLo+(bi-1)*sNx,
+     &             myYGlobalLo+(bj-1)*sNy /)
+              err = nf90_put_var(ncid, varid,
+     &             Ro_surf(1:sNx, 1:sNy,bi,bj) - 
+     &             R_low(1:sNx, 1:sNy,bi,bj),
+     &             start = start(1:2), count = count(1:2))
+              CALL nf90ERR(err, "Putting Depth into file", myThid)
+           enddo
+        enddo
+
+C     Reference densities...
+
+        DO k=1,Nr+1
+           ks(k) = phiRef(2*k-1)
+        ENDDO
+        err = nf90_inq_varid(ncid, "PHrefF", varid)
+        CALL nf90ERR(err, "Getting PHRefF varid",myThid)
+        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90_put_var(ncid, varid,
+     &       ks(1:NR+1),
+     &       start = (/ 1 /) ,
+     &       count = (/ Nr+1 /) )
+        
+        DO k=1,Nr
+           ks(k) = phiRef(2*k)
+        ENDDO
+        err = nf90_inq_varid(ncid, "PHrefC", varid)
+        CALL nf90ERR(err, "Getting PHRefC varid",myThid)
+        err = nf90_var_par_access(ncid, varid, nf90_collective)
+        err = nf90_put_var(ncid, varid,
+     &       ks(1:NR),
+     &       start = (/ 1 /) ,
+     &       count = (/ Nr /) )
+
+
+CCCCCCCCCCCCCCCCCC
+C     Set file attributes
+        err = nf90_redef(ncid)
+        CALL nf90ERR(err, "Entering Def mode for file attributes"
+     $       ,myThid)
+        
+        err = nf90_put_att(ncid, NF90_GLOBAL, 'the_run_name',
+     $       the_run_name)
+
+#ifdef THISVER
+        err = nf90_put_att( ncid, NF90_GLOBAL, 'MITgcm_version',
+     $       THISVER)
+        err = nf90_put_att( ncid, NF90_GLOBAL, 'source',
+     $       THISVER)
+#endif
+#ifdef THISUSER
+        err = nf90_put_att( ncid, NF90_GLOBAL, 'build_user',
+     &       THISUSER)
+#endif
+#ifdef THISHOST
+        err = nf90_put_att( ncid, NF90_GLOBAL, 'build_host', 
+     &       THISHOST)
+#endif
+#ifdef THISDATE
+        err = nf90_put_att( ncid, NF90_GLOBAL, 'build_date', 
+     &       THISDATE)
+#endif
+
+        err = nf90_put_att( ncid, NF90_GLOBAL, 'MITgcm_URL',
+     $       'http://mitgcm.org')
+
+        err = nf90_put_att( ncid, NF90_GLOBAL, 'history',
+     $       'Saved from nf90io')
+
+        err = nf90_enddef(ncid)
+        CALL nf90ERR(err, "Ending def mode file attributes",myThid)
+
+        
+CCCCCCCCCCCCCCCCCC
+C     Close
+        err = nf90_close(ncid)
+        CALL nf90ERR(err, "Closing after setting up grids",myThid)
+        
+        RETURN
+        END

--- a/pkg/nf90io/nf90io_utils.F
+++ b/pkg/nf90io/nf90io_utils.F
@@ -1,0 +1,317 @@
+#include "PACKAGES_CONFIG.h"
+#include "CPP_OPTIONS.h"
+
+CCCCCCCCCCCCCCC
+      SUBROUTINE NF90IO_FILL_3Dnorec(ncid, vname, dat, myThid)
+
+C     !DESCRIPTION:
+C     Convenience function for handling all MNC and NetCDF library
+C     errors.
+      use netcdf
+      implicit none
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+#include "GRID.h"
+
+
+      character*(*) vname
+      INTEGER ncid, myThid, iRec
+      _RL dat (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+
+      INTEGER start(3), count(3), rec_dimid
+      INTEGER bi, bj, err, varid
+
+      err = nf90_inq_varid(ncid, vname, varid)
+      CALL nf90ERR(err, "Getting varid",myThid)
+      err = nf90_var_par_access(ncid, varid, nf90_collective)
+      CALL nf90ERR(err, "Setting varid paraccess",myThid)
+
+      count = (/  sNx, sNy, Nr /)
+      do bj = 1,nSy
+         do bi = 1,nSx
+C     NOT tested w/ more than one thread be processor, so
+C     maybe incorrect.
+            start = (/ myXGlobalLo+(bi-1)*sNx,
+     &           myYGlobalLo+(bj-1)*sNy,
+     &           1/)
+            err = nf90_put_var(ncid, varid,
+     &             dat(1:sNx, 1:sNy, 1:Nr, bi, bj),
+     &              start = start, count = count)
+            CALL nf90ERR(err, "Putting data into file", myThid)
+         enddo
+      enddo
+      RETURN
+      END
+
+CCCCCCCCCCCCCCCCCCCCCCCCCCCc
+
+CCCCCCCCCCCCCCC
+      SUBROUTINE NF90IO_FILL_4D(ncid, vname, dat, iRec, myThid)
+
+C     !DESCRIPTION:
+C     Convenience function for handling all MNC and NetCDF library
+C     errors.
+      use netcdf
+      implicit none
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+#include "GRID.h"
+
+
+      character*(*) vname
+      INTEGER ncid, myThid, iRec
+      _RL dat (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
+
+      INTEGER start(4), count(4), rec_dimid
+      INTEGER bi, bj, err, varid
+
+      err = nf90_inq_varid(ncid, vname, varid)
+      CALL nf90ERR(err, "Getting varid",myThid)
+      err = nf90_var_par_access(ncid, varid, nf90_collective)
+      CALL nf90ERR(err, "Setting varid paraccess",myThid)
+
+      count = (/  sNx, sNy, Nr, 1 /)
+      do bj = 1,nSy
+         do bi = 1,nSx
+C     NOT tested w/ more than one thread be processor, so
+C     maybe incorrect.
+            start = (/ myXGlobalLo+(bi-1)*sNx,
+     &           myYGlobalLo+(bj-1)*sNy,
+     &           1,
+     &           iRec /)
+            err = nf90_put_var(ncid, varid,
+     &             dat(1:sNx, 1:sNy, 1:Nr, bi, bj),
+     &              start = start, count = count)
+            CALL nf90ERR(err, "Putting data into file", myThid)
+         enddo
+      enddo
+      RETURN
+      END
+
+CCCCCCCCCCCCCCCCCCCCCCCCCCCc
+
+CCCCCCCCCCCCCCC
+      SUBROUTINE NF90IO_FILL_4DNlev(ncid, vname, nlev, dat, iRec,
+     $     myThid)
+
+C     !DESCRIPTION:
+C     Convenience function for handling all MNC and NetCDF library
+C     errors.
+      use netcdf
+      implicit none
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+#include "GRID.h"
+
+      character*(*) vname
+      INTEGER ncid, myThid, nlev, iRec
+      _RL dat (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nlev,nSx,nSy)
+
+      INTEGER start(4), count(4), rec_dimid
+      INTEGER bi, bj, err, varid
+
+      err = nf90_inq_varid(ncid, vname, varid)
+      CALL nf90ERR(err, "Getting varid",myThid)
+      err = nf90_var_par_access(ncid, varid, nf90_collective)
+      CALL nf90ERR(err, "Setting varid paraccess",myThid)
+
+      count = (/  sNx, sNy, nlev, 1 /)
+      do bj = 1,nSy
+         do bi = 1,nSx
+C     NOT tested w/ more than one thread be processor, so
+C     maybe incorrect.
+            start = (/ myXGlobalLo+(bi-1)*sNx,
+     &           myYGlobalLo+(bj-1)*sNy,
+     &           1,
+     &           iRec /)
+            err = nf90_put_var(ncid, varid,
+     &             dat(1:sNx, 1:sNy, 1:nlev, bi, bj),
+     &              start = start, count = count)
+            CALL nf90ERR(err, "Putting data into file", myThid)
+         enddo
+      enddo
+      RETURN
+      END
+
+CCCCCCCCCCCCCCCCCCCCCCCCCCCc
+
+
+CCCCCCCCCCCCCCC
+      SUBROUTINE NF90IO_FILL_3D(ncid, vname, dat, iRec, myThid)
+
+C     !DESCRIPTION:
+C     Convenience function for handling all MNC and NetCDF library
+C     errors.
+      use netcdf
+      implicit none
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+#include "GRID.h"
+
+
+      character*(*) vname
+      INTEGER ncid, myThid, iRec
+      _RL dat (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+
+      INTEGER start(3), count(3), rec_dimid
+      INTEGER bi, bj, err, varid
+
+      err = nf90_inq_varid(ncid, vname, varid)
+      CALL nf90ERR(err, "Getting varid",myThid)
+      err = nf90_var_par_access(ncid, varid, nf90_collective)
+      CALL nf90ERR(err, "Setting varid paraccess",myThid)
+
+      count = (/  sNx, sNy, 1 /)
+      do bj = 1,nSy
+         do bi = 1,nSx
+C     NOT tested w/ more than one thread be processor, so
+C     maybe incorrect.
+            start = (/ myXGlobalLo+(bi-1)*sNx,
+     &           myYGlobalLo+(bj-1)*sNy,
+     &           iRec /)
+            err = nf90_put_var(ncid, varid,
+     &             dat(1:sNx, 1:sNy, bi, bj),
+     &              start = start, count = count)
+            CALL nf90ERR(err, "Putting data into file", myThid)
+         enddo
+      enddo
+      RETURN
+      END
+
+CCCCCCCCCCCCCCCCCCCCCCCCCCCc
+
+      SUBROUTINE NF90IO_FILL_2Dnorec(ncid, vname, dat, myThid)
+
+C     !DESCRIPTION:
+C     Convenience function for handling all MNC and NetCDF library
+C     errors.
+      use netcdf
+      implicit none
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+#include "GRID.h"
+
+
+      character*(*) vname
+      INTEGER ncid, myThid
+      _RL dat (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
+
+      INTEGER start(2), count(2), rec_dimid
+      INTEGER bi, bj, err, varid
+
+      err = nf90_inq_varid(ncid, vname, varid)
+      CALL nf90ERR(err, "Getting varid",myThid)
+      err = nf90_var_par_access(ncid, varid, nf90_collective)
+      CALL nf90ERR(err, "Setting varid paraccess",myThid)
+
+      count = (/  sNx, sNy /)
+      do bj = 1,nSy
+         do bi = 1,nSx
+C     NOT tested w/ more than one thread be processor, so
+C     maybe incorrect.
+            start = (/ myXGlobalLo+(bi-1)*sNx,
+     &           myYGlobalLo+(bj-1)*sNy /)
+            err = nf90_put_var(ncid, varid,
+     &             dat(1:sNx, 1:sNy, bi, bj),
+     &              start = start, count = count)
+            CALL nf90ERR(err, "Putting data into file", myThid)
+         enddo
+      enddo
+      RETURN
+      END
+
+
+CCCCCCCCCCCCCCC
+      SUBROUTINE nf90DefineVar(ncid, varname, dimnames, attnames,
+     $     attvals, varid, myThid)
+      
+C     !USES:
+      use netcdf
+
+      implicit none
+#include "EEPARAMS.h"
+      INTEGER  myThid, ncid
+      CHARACTER(*) varname
+      CHARACTER (len=250), dimension(:) :: dimnames
+      CHARACTER attnames(250)*10
+      CHARACTER attvals(250)*10
+      
+C     OUTPUT:
+      INTEGER varid
+CEOP
+
+C     !LOCAL VARIABLES:
+      integer i,lenm, dim1, dim2, dim3, dim4, err
+      integer dims(4), n
+      
+      n = size(dimnames(:4))
+      
+      err = nf90_def_var(ncid, varname, NF90_INT, (/ 1 /), varid)
+      CALL nf90ERR(err,"Adding i variable",myThid)
+      err = nf90_put_att(ncid, varid,
+     $     "standard_name", "x_grid_index")
+      err = nf90_put_att(ncid, varid, "long_name",
+     $     "x-dimension of the t grid")
+      err = nf90_put_att(ncid, varid, "units",
+     $     "")
+      CALL nf90ERR(err,"Setting attributes",myThid)
+
+      RETURN
+      END
+
+CCCCCCCCCCCCCCCC
+      SUBROUTINE nf90ERR( status, msg, myThid )
+
+C     !DESCRIPTION:
+C     Convenience function for handling all MNC and NetCDF library
+C     errors.
+
+C     !USES:
+      use netcdf
+
+      implicit none
+#include "EEPARAMS.h"
+
+C     !DESCRIPTION:
+
+C     !USES:
+      INTEGER  myThid, status
+      character*(*) msg
+CEOP
+
+C     !LOCAL VARIABLES:
+      integer i,lenm
+      character*(MAX_LEN_MBUF) msgbuf
+
+C     Functions
+      integer ILNBLNK
+
+      DO i = 1,MAX_LEN_MBUF
+        msgbuf(i:i) = ' '
+      ENDDO
+
+      IF ( status .NE. NF90_NOERR ) THEN
+        write(msgbuf,'(2a)') 'NetCDF ERROR: '
+        lenm = ILNBLNK(msgbuf)
+        print *, msgbuf(1:lenm)
+        CALL print_error(msgbuf(1:lenm), mythid)
+        print *, '==='
+        print *, NF90_STRERROR(status)
+        print *, '==='
+        lenm = ILNBLNK(msg)
+        lenm = MIN(lenm,MAX_LEN_MBUF-11)
+        write(msgbuf,'(2a)') 'NF90IO ERROR: ', msg(1:lenm)
+        lenm = ILNBLNK(msgbuf)
+        print *, msgbuf(1:lenm)
+        CALL print_error(msgbuf(1:lenm), mythid)
+        STOP 'ABNORMAL END: S/R NF90ERR'
+      ENDIF
+      RETURN
+      END
+
+

--- a/pkg/nf90io/nf90io_utils.F
+++ b/pkg/nf90io/nf90io_utils.F
@@ -2,6 +2,60 @@
 #include "CPP_OPTIONS.h"
 
 CCCCCCCCCCCCCCC
+      FUNCTION NF90IO_VAR_PAR_ACCESS(ncid, varid)
+
+      use netcdf
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "EESUPPORT.h"
+
+      
+
+C     !DESCRIPTION:
+C     Convenience wrappper around NF90_VAR_PAR_ACCESS that 
+C     doesnt do anything if usingMPI is false
+
+      INTEGER, intent(in) :: ncid,varid
+      INTEGER  :: err
+      IF (usingMPI) THEN
+         err = nf90_var_par_access(ncid, varid, nf90_collective)
+      ELSE
+         err = NF90_NOERR
+      ENDIF
+      NF90IO_VAR_PAR_ACCESS = err
+      END FUNCTION
+
+CCCCCCCCCCCCCCC
+      FUNCTION NF90IO_OPEN(fname, ncid)
+
+      use netcdf
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "EESUPPORT.h"
+
+C     !DESCRIPTION:
+C     Convenience wrappper around NF90_OPEN that 
+C     opens in non-parallel if usingMPI not set
+
+      CHARACTER (LEN=*), intent(in) :: fname
+      INTEGER  :: ncid, err
+
+      IF (usingMPI) THEN
+#ifdef ALLOW_USE_MPI
+         err = nf90_open(fname, IOR(nf90_write, nf90_mpiio),
+     $        ncid,
+     $        comm=MPI_COMM_WORLD, info=MPI_INFO_NULL)
+#endif
+      ELSE
+         err = nf90_open(fname, nf90_write,ncid)
+      ENDIF
+
+      NF90IO_OPEN = err
+      END FUNCTION
+      
+
+
+CCCCCCCCCCCCCCC
       SUBROUTINE NF90IO_FILL_3Dnorec(ncid, vname, dat, myThid)
 
 C     !DESCRIPTION:
@@ -13,6 +67,7 @@ C     errors.
 #include "EEPARAMS.h"
 #include "PARAMS.h"
 #include "GRID.h"
+#include "NF90IO.h"
 
 
       character*(*) vname
@@ -24,8 +79,8 @@ C     errors.
 
       err = nf90_inq_varid(ncid, vname, varid)
       CALL nf90ERR(err, "Getting varid",myThid)
-      err = nf90_var_par_access(ncid, varid, nf90_collective)
-      CALL nf90ERR(err, "Setting varid paraccess",myThid)
+      err = nf90io_var_par_access(ncid, varid)
+      CALL nf90ERR(err, "Setting varid paraccess 3D",myThid)
 
       count = (/  sNx, sNy, Nr /)
       do bj = 1,nSy
@@ -58,6 +113,7 @@ C     errors.
 #include "EEPARAMS.h"
 #include "PARAMS.h"
 #include "GRID.h"
+#include "NF90IO.h"
 
 
       character*(*) vname
@@ -69,8 +125,8 @@ C     errors.
 
       err = nf90_inq_varid(ncid, vname, varid)
       CALL nf90ERR(err, "Getting varid",myThid)
-      err = nf90_var_par_access(ncid, varid, nf90_collective)
-      CALL nf90ERR(err, "Setting varid paraccess",myThid)
+      err = nf90io_var_par_access(ncid, varid)
+      CALL nf90ERR(err, "Setting varid paraccess 4d",myThid)
 
       count = (/  sNx, sNy, Nr, 1 /)
       do bj = 1,nSy
@@ -105,6 +161,7 @@ C     errors.
 #include "EEPARAMS.h"
 #include "PARAMS.h"
 #include "GRID.h"
+#include "NF90IO.h"
 
       character*(*) vname
       INTEGER ncid, myThid, nlev, iRec
@@ -115,8 +172,8 @@ C     errors.
 
       err = nf90_inq_varid(ncid, vname, varid)
       CALL nf90ERR(err, "Getting varid",myThid)
-      err = nf90_var_par_access(ncid, varid, nf90_collective)
-      CALL nf90ERR(err, "Setting varid paraccess",myThid)
+      err = nf90io_var_par_access(ncid, varid)
+      CALL nf90ERR(err, "Setting varid paraccess 4dN",myThid)
 
       count = (/  sNx, sNy, nlev, 1 /)
       do bj = 1,nSy
@@ -151,6 +208,7 @@ C     errors.
 #include "EEPARAMS.h"
 #include "PARAMS.h"
 #include "GRID.h"
+#include "NF90IO.h"
 
 
       character*(*) vname
@@ -162,8 +220,8 @@ C     errors.
 
       err = nf90_inq_varid(ncid, vname, varid)
       CALL nf90ERR(err, "Getting varid",myThid)
-      err = nf90_var_par_access(ncid, varid, nf90_collective)
-      CALL nf90ERR(err, "Setting varid paraccess",myThid)
+      err = nf90io_var_par_access(ncid, varid)
+      CALL nf90ERR(err, "Setting varid paraccess 3d",myThid)
 
       count = (/  sNx, sNy, 1 /)
       do bj = 1,nSy
@@ -195,6 +253,7 @@ C     errors.
 #include "EEPARAMS.h"
 #include "PARAMS.h"
 #include "GRID.h"
+#include "NF90IO.h"
 
 
       character*(*) vname
@@ -206,8 +265,8 @@ C     errors.
 
       err = nf90_inq_varid(ncid, vname, varid)
       CALL nf90ERR(err, "Getting varid",myThid)
-      err = nf90_var_par_access(ncid, varid, nf90_collective)
-      CALL nf90ERR(err, "Setting varid paraccess",myThid)
+      err = nf90io_var_par_access(ncid, varid)
+      CALL nf90ERR(err, "Setting varid paraccess 2dnr",myThid)
 
       count = (/  sNx, sNy /)
       do bj = 1,nSy

--- a/tools/genmake2
+++ b/tools/genmake2
@@ -1086,9 +1086,9 @@ EOF
     echo " --> set HAVE_NETCDF='$HAVE_NETCDF'" >> $LOGFILE
 }
 
-check_nf90io_libs()  {
+check_nf90io_mpi_libs()  {
     if test ! "x$SKIP_NF90IO_CHECK" = x ; then
-	return
+	    return
     fi
     echo >> $LOGFILE
     echo "running: check_nf90io_libs()" >> $LOGFILE
@@ -1122,7 +1122,7 @@ check_nf90io_libs()  {
 	else
 	# try again with "-lnetcdff" added to the libs
 	    echo "==> try again with added '-lnetcdff -lnetcdf'" > f90tst_parallel.log
-	    
+
 	    echo "$FC $FFLAGS $FOPTIM -c f90tst_parallel.f90 \ " >> f90tst_parallel.log
 	    echo "  &&  $LINK $FFLAGS $FOPTIM -o f90tst_parallel.o $LIBS -lnetcdf" >> f90tst_parallel.log
 	    $FC $FFLAGS $FOPTIM  $INCLUDES -c  ${TOOLSDIR}/maketests/f90tst_parallel.f90 >> f90tst_parallel.log 2>&1  \
@@ -1138,6 +1138,61 @@ check_nf90io_libs()  {
 	fi
     fi
     rm -f f90tst_parallel*
+    echo " --> set HAVE_NF90IO='$HAVE_NF90IO'" >> $LOGFILE
+}
+
+check_nf90io_nompi_libs()  {
+    if test ! "x$SKIP_NF90IO_CHECK" = x ; then
+	    return
+    fi
+    echo >> $LOGFILE
+    echo "running: check_nf90io_libs()" >> $LOGFILE
+    echo "===  f90tst_vars.f90  >>>" > f90tst_parallel.log
+    #cat genmake_tnc.F >> f90tst_vars.log
+    echo "<<<  f90tst_vars.f90 ===" >> f90tst_vars.log
+    echo "$FC $FFLAGS $FOPTIM -c f90tst_vars.f90 \ " >> f90tst_parallel.log
+    echo "  &&  $LINK $FFLAGS $FOPTIM -o f90tst_vars.o $LIBS" >> f90tst_vars.log
+    $FC $FFLAGS $FOPTIM  $INCLUDES -c ${TOOLSDIR}/maketests/f90tst_vars.f90 >> f90tst_vars.log 2>&1  \
+	&&  $LINK $FFLAGS $FOPTIM -o  f90tst_vars f90tst_vars.o $LIBS >> f90tst_vars.log 2>&1
+    RET_COMPILE=$?
+    cat f90tst_vars.log >> $LOGFILE
+
+    if test "x$RET_COMPILE" = x0 ; then
+	HAVE_NF90IO=t
+	echo "check_nf90io_libs: successful" >> $LOGFILE
+    else
+	# try again with "-lnetcdf" added to the libs
+	echo "==> try again with added '-lnetcdf'" > f90tst_vars.log
+	echo "$FC $FFLAGS $FOPTIM -c f90tst_vars.f90 \ " >> f90tst_vars.log
+	echo "  &&  $LINK $FFLAGS $FOPTIM -o f90tst_vars.o $LIBS -lnetcdf" >> f90tst_vars.log
+	$FC $FFLAGS $FOPTIM  $INCLUDES -c  ${TOOLSDIR}/maketests/f90tst_vars.f90 >> f90tst_vars.log 2>&1  \
+	    &&  $LINK $FFLAGS $FOPTIM -o  f90tst_vars f90tst_vars.o $LIBS -lnetcdf >> f90tst_vars.log 2>&1
+	RET_COMPILE=$?
+	echo >> $LOGFILE
+	cat f90tst_vars.log >> $LOGFILE
+	if test "x$RET_COMPILE" = x0 ; then
+	    LIBS="$LIBS -lnetcdf"
+	    HAVE_NF90IO=t
+	    echo "check_nf90io_libs: successful" >> $LOGFILE
+	else
+	# try again with "-lnetcdff" added to the libs
+	    echo "==> try again with added '-lnetcdff -lnetcdf'" > f90tst_vars.log
+
+	    echo "$FC $FFLAGS $FOPTIM -c f90tst_vars.f90 \ " >> f90tst_vars.log
+	    echo "  &&  $LINK $FFLAGS $FOPTIM -o f90tst_vars.o $LIBS -lnetcdf" >> f90tst_vars.log
+	    $FC $FFLAGS $FOPTIM  $INCLUDES -c  ${TOOLSDIR}/maketests/f90tst_vars.f90 >> f90tst_vars.log 2>&1  \
+		&&  $LINK $FFLAGS $FOPTIM -o f90tst_vars f90tst_vars.o $LIBS -lnetcdf -lnetcdff >> f90tst_vars.log 2>&1
+	    RET_COMPILE=$?
+	    echo >> $LOGFILE
+	    cat f90tst_vars.log >> $LOGFILE
+	    if test "x$RET_COMPILE" = x0 ; then
+		LIBS="$LIBS -lnetcdf -lnetcdff"
+		HAVE_NF90IO=t
+		echo "check_nf90io_libs: successful" >> $LOGFILE
+	    fi
+	fi
+    fi
+    rm -f f90tst_vars*
     echo " --> set HAVE_NF90IO='$HAVE_NF90IO'" >> $LOGFILE
 }
 
@@ -2143,7 +2198,13 @@ fi
 
 
 printf "  Can we create NF90-enabled binaries...  "
-check_nf90io_libs
+if  [[ $DEFINES ==  *"-DALLOW_USE_MPI"* ]]; then
+    printf "with mpi...  "
+    check_nf90io_mpi_libs
+else
+    printf "without mpi...  "
+    check_nf90io_nompi_libs
+fi
 if test "x$HAVE_NF90IO" != x ; then
     DEFINES="$DEFINES -DHAVE_NF90IO"
     echo "yes"
@@ -3106,7 +3167,7 @@ cat >>$MAKEFILE <<EOF
 all: fwd_exe_target
 fwd_exe_target:
 	@echo Update AD_CONFIG.h and make \$(EXECUTABLE)
-	@$BASH\$(TOOLSDIR)/convert_cpp_cmd2defines "Forward version" -bAD_CONFIG_H -UALLOW_ADJOINT_RUN -UALLOW_TANGENTLINEAR_RUN > ad_config.template
+	@$BASH\$(TOOLSDIR)/convert_cpp_cmd2defines "Forward version" -bAD_CONFIG_H -UALLOW_ADJOINT_RUN -UALLOWTANGENTLINEAR_RUN > ad_config.template
 	@cmp ad_config.template AD_CONFIG.h || cat ad_config.template > AD_CONFIG.h
 	@-rm -f ad_config.template
 	\$(MAKE) -f \$(MAKEFILE) \$(EXECUTABLE)

--- a/tools/genmake2
+++ b/tools/genmake2
@@ -1086,6 +1086,62 @@ EOF
     echo " --> set HAVE_NETCDF='$HAVE_NETCDF'" >> $LOGFILE
 }
 
+check_nf90io_libs()  {
+    if test ! "x$SKIP_NF90IO_CHECK" = x ; then
+	return
+    fi
+    echo >> $LOGFILE
+    echo "running: check_nf90io_libs()" >> $LOGFILE
+    echo "===  f90tst_parallel.f90  >>>" > f90tst_parallel.log
+    #cat genmake_tnc.F >> f90tst_parallel.log
+    echo "<<<  f90tst_parallel.f90 ===" >> f90tst_parallel.log
+    echo "$FC $FFLAGS $FOPTIM -c f90tst_parallel.f90 \ " >> f90tst_parallel.log
+    echo "  &&  $LINK $FFLAGS $FOPTIM -o f90tst_parallel.o $LIBS" >> f90tst_parallel.log
+    $FC $FFLAGS $FOPTIM  $INCLUDES -c ${TOOLSDIR}/maketests/f90tst_parallel.f90 >> f90tst_parallel.log 2>&1  \
+	&&  $LINK $FFLAGS $FOPTIM -o  f90tst_parallel f90tst_parallel.o $LIBS >> f90tst_parallel.log 2>&1
+    RET_COMPILE=$?
+    cat f90tst_parallel.log >> $LOGFILE
+
+    if test "x$RET_COMPILE" = x0 ; then
+	HAVE_NF90IO=t
+	echo "check_nf90io_libs: successful" >> $LOGFILE
+    else
+	# try again with "-lnetcdf" added to the libs
+	echo "==> try again with added '-lnetcdf'" > f90tst_parallel.log
+	echo "$FC $FFLAGS $FOPTIM -c f90tst_parallel.f90 \ " >> f90tst_parallel.log
+	echo "  &&  $LINK $FFLAGS $FOPTIM -o f90tst_parallel.o $LIBS -lnetcdf" >> f90tst_parallel.log
+	$FC $FFLAGS $FOPTIM  $INCLUDES -c  ${TOOLSDIR}/maketests/f90tst_parallel.f90 >> f90tst_parallel.log 2>&1  \
+	    &&  $LINK $FFLAGS $FOPTIM -o  f90tst_parallel f90tst_parallel.o $LIBS -lnetcdf >> f90tst_parallel.log 2>&1
+	RET_COMPILE=$?
+	echo >> $LOGFILE
+	cat f90tst_parallel.log >> $LOGFILE
+	if test "x$RET_COMPILE" = x0 ; then
+	    LIBS="$LIBS -lnetcdf"
+	    HAVE_NF90IO=t
+	    echo "check_nf90io_libs: successful" >> $LOGFILE
+	else
+	# try again with "-lnetcdff" added to the libs
+	    echo "==> try again with added '-lnetcdff -lnetcdf'" > f90tst_parallel.log
+	    
+	    echo "$FC $FFLAGS $FOPTIM -c f90tst_parallel.f90 \ " >> f90tst_parallel.log
+	    echo "  &&  $LINK $FFLAGS $FOPTIM -o f90tst_parallel.o $LIBS -lnetcdf" >> f90tst_parallel.log
+	    $FC $FFLAGS $FOPTIM  $INCLUDES -c  ${TOOLSDIR}/maketests/f90tst_parallel.f90 >> f90tst_parallel.log 2>&1  \
+		&&  $LINK $FFLAGS $FOPTIM -o f90tst_parallel f90tst_parallel.o $LIBS -lnetcdf -lnetcdff >> f90tst_parallel.log 2>&1
+	    RET_COMPILE=$?
+	    echo >> $LOGFILE
+	    cat f90tst_parallel.log >> $LOGFILE
+	    if test "x$RET_COMPILE" = x0 ; then
+		LIBS="$LIBS -lnetcdf -lnetcdff"
+		HAVE_NF90IO=t
+		echo "check_nf90io_libs: successful" >> $LOGFILE
+	    fi
+	fi
+    fi
+    rm -f f90tst_parallel*
+    echo " --> set HAVE_NF90IO='$HAVE_NF90IO'" >> $LOGFILE
+}
+
+
 check_lapack_libs()  {
     if test "x$CHECK_FOR_LAPACK" = xf ; then return ; fi
     echo >> $LOGFILE
@@ -2074,6 +2130,28 @@ else
     echo "no"
 fi
 
+if test "x${TOOLSDIR}" = x ; then
+    TOOLSDIR="$ROOTDIR/tools"
+    TOOLSDIRMK='$(ROOTDIR)'"/tools"
+else
+    TOOLSDIRMK=${TOOLSDIR}
+fi
+if test ! -d ${TOOLSDIR} ; then
+    echo "Error: the specified TOOLSDIR (\"$TOOLSDIR\") does not exist!"
+    exit 1
+fi
+
+
+printf "  Can we create NF90-enabled binaries...  "
+check_nf90io_libs
+if test "x$HAVE_NF90IO" != x ; then
+    DEFINES="$DEFINES -DHAVE_NF90IO"
+    echo "yes"
+else
+    echo "no"
+fi
+
+
 printf "  Can we create LAPACK-enabled binaries...  "
 check_lapack_libs
 if test "x$HAVE_LAPACK" != x ; then
@@ -2135,16 +2213,6 @@ if test ! -d ${EXEDIR} ; then
     exit 1
 fi
 
-if test "x${TOOLSDIR}" = x ; then
-    TOOLSDIR="$ROOTDIR/tools"
-    TOOLSDIRMK='$(ROOTDIR)'"/tools"
-else
-    TOOLSDIRMK=${TOOLSDIR}
-fi
-if test ! -d ${TOOLSDIR} ; then
-    echo "Error: the specified TOOLSDIR (\"$TOOLSDIR\") does not exist!"
-    exit 1
-fi
 if test "x$S64" = x ; then
     echo "3.0 _d 3" | ${TOOLSDIR}/set64bitConst.sh > /dev/null 2>&1
     RETVAL=$?
@@ -2172,7 +2240,6 @@ EOF
     fi
 fi
 THIS_SCRIPT=`echo ${0} | sed 's:'$TOOLSDIR':\$(TOOLSDIR):'`
-
 EXECUTABLE=${EXECUTABLE:-mitgcmuv}
 
 #  Set Standard Code Directories:
@@ -2382,6 +2449,35 @@ else
 	fi
     fi
 fi
+
+#  Check for package nf90io: if NF90 is available, then build the nf90io
+#  template files ; otherwise, delete nf90io from the list of packages.
+echo " $PACKAGES " | grep ' nf90io ' > /dev/null 2>&1
+nf90_in=$?
+if test "x$HAVE_NF90IO" != xt ; then
+    if test "x$nf90_in" = x0 ; then
+	cat <<EOF
+*********************************************************************
+WARNING: the "nf90io" package was enabled but tests failed to compile
+  NF90 applications.  Please check that:
+
+  1) NF90 is correctly installed for this compiler and
+  2) the LIBS variable (within the "optfile") specifies the correct
+       NetCDF library to link against.
+  2) the INCLUDE variable (within the "optfile") specifies the correct
+       NetCDF header files to include.
+
+  Due to this failure, the "nf90io" package is now DISABLED.
+*********************************************************************
+EOF
+	PACKAGES=`echo $PACKAGES | sed -e 's/nf90io//g'`
+	DISABLE="$DISABLE nf90io"
+    else
+    #  this prevent to add nf90io (due to pdepend rules) if not available
+	DISABLE="$DISABLE nf90io"
+    fi
+fi
+
 
 #  Check for package PROFILES: if NetCDF is not available,
 #  then delete profiles from the list of available packages.
@@ -3124,18 +3220,18 @@ CPPCMD = cat \$< | ${CPP} \$(DEFINES) \$(INCLUDES) | ${S64}
 .F.$FS:
 	\$(CPPCMD)  > \$@
 .$FS.o:
-	\$(FC) \$(FFLAGS) \$(FOPTIM) -c \$<
+	\$(FC) \$(FFLAGS) \$(INCLUDES) \$(FOPTIM) -c \$<
 .F.o:
-	\$(FC) \$(FFLAGS) \$(FOPTIM) -c \$<
+	\$(FC) \$(FFLAGS) \$(INCLUDES) \$(FOPTIM) -c \$<
 .F90.$FS90:
 	\$(CPPCMD)  > \$@
 .FF90.f$FS90:
 	\$(CPPCMD)  > \$@
 .$FS90.o:
-	\$(F90C) \$(F90FLAGS) \$(F90OPTIM) -c \$<
+	\$(F90C) \$(F90FLAGS) \$(INCLUDES) \$(F90OPTIM) -c \$<
 .f$FS90.o:
 	cp \$< \$(basename  \$<).f90
-	\$(F90C) \$(F90FLAGS) \$(F90OPTIM) -c \$(F90FIXEDFORMAT) \$(basename  \$<).f90
+	\$(F90C) \$(F90FLAGS) \$(INCLUDES) \$(F90OPTIM) -c \$(F90FIXEDFORMAT) \$(basename  \$<).f90
 .c.o:
 	\$(CC) \$(CFLAGS) \$(DEFINES) \$(INCLUDES) -c \$<
 .flow.flowdir:

--- a/tools/genmake2
+++ b/tools/genmake2
@@ -3167,7 +3167,7 @@ cat >>$MAKEFILE <<EOF
 all: fwd_exe_target
 fwd_exe_target:
 	@echo Update AD_CONFIG.h and make \$(EXECUTABLE)
-	@$BASH\$(TOOLSDIR)/convert_cpp_cmd2defines "Forward version" -bAD_CONFIG_H -UALLOW_ADJOINT_RUN -UALLOWTANGENTLINEAR_RUN > ad_config.template
+	@$BASH\$(TOOLSDIR)/convert_cpp_cmd2defines "Forward version" -bAD_CONFIG_H -UALLOW_ADJOINT_RUN -UALLOW_TANGENTLINEAR_RUN > ad_config.template
 	@cmp ad_config.template AD_CONFIG.h || cat ad_config.template > AD_CONFIG.h
 	@-rm -f ad_config.template
 	\$(MAKE) -f \$(MAKEFILE) \$(EXECUTABLE)

--- a/tools/maketests/f90tst_parallel.f90
+++ b/tools/maketests/f90tst_parallel.f90
@@ -1,0 +1,164 @@
+!     This is part of the netCDF package.
+!     Copyright 2006 University Corporation for Atmospheric Research/Unidata.
+!     See COPYRIGHT file for conditions of use.
+
+!     This program tests netCDF-4 parallel I/O functions from fortran.
+
+!     We are writing 2D data, a 6 x 12 grid, on 4 processors. Each
+!     processor will write it's rank to it's quarter of the array. The
+!     result will be (in CDL):
+!
+! netcdf f90tst_parallel {
+! dimensions:
+! 	x = 16 ;
+! 	y = 16 ;
+! variables:
+! 	int data(x, y) ;
+! data:
+! 
+!  data =
+!   0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1,
+!   0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1,
+!   0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1,
+!   0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1,
+!   0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1,
+!   0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1,
+!   0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1,
+!   0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1,
+!   2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3,
+!   2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3,
+!   2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3,
+!   2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3,
+!   2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3,
+!   2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3,
+!   2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3,
+!   2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3 ;
+! }
+
+!     $Id: f90tst_parallel.f90,v 1.6 2010/05/25 13:53:04 ed Exp $
+
+program f90tst_parallel
+  use typeSizes
+  use netcdf
+  implicit none
+  include 'mpif.h'
+  
+  ! This is the name of the data file we will create.
+  character (len = *), parameter :: FILE_NAME = "f90tst_parallel.nc"
+
+  integer, parameter :: MAX_DIMS = 2
+  integer, parameter :: NX = 16, NY = 16
+  integer, parameter :: NUM_PROC = 4
+  integer :: ncid, varid, dimids(MAX_DIMS), chunksizes(MAX_DIMS), chunksizes_in(MAX_DIMS)
+  integer :: x_dimid, y_dimid, contig
+  integer :: data_out(NY / 2, NX / 2), data_in(NY / 2, NX / 2)
+  integer :: mode_flag
+  integer :: nvars, ngatts, ndims, unlimdimid, file_format
+  integer :: x, y, retval
+  integer :: p, my_rank, ierr
+  integer :: start(MAX_DIMS), count(MAX_DIMS)
+
+  call MPI_Init(ierr)
+  call MPI_Comm_rank(MPI_COMM_WORLD, my_rank, ierr)
+  call MPI_Comm_size(MPI_COMM_WORLD, p, ierr)
+
+  if (my_rank .eq. 0) then
+     print *, ' '
+     print *, '*** Testing netCDF-4 parallel I/O from Fortran 90.'
+  endif
+
+  ! There must be 4 procs for this test.
+  if (p .ne. 4) then
+     print *, 'Sorry, this test program must be run on four processors.'
+     stop 2 
+  endif
+
+  ! Create some pretend data.
+  do x = 1, NX / 2
+     do y = 1, NY / 2
+        data_out(y, x) = my_rank
+     end do
+  end do
+
+  ! Create the netCDF file. 
+  mode_flag = IOR(nf90_netcdf4, nf90_classic_model) 
+  mode_flag = IOR(mode_flag, nf90_mpiio) 
+  call handle_err(nf90_create(FILE_NAME, mode_flag, ncid, comm = MPI_COMM_WORLD, &
+       info = MPI_INFO_NULL))
+
+  ! Define the dimensions.
+  call handle_err(nf90_def_dim(ncid, "x", NX, x_dimid))
+  call handle_err(nf90_def_dim(ncid, "y", NY, y_dimid))
+  dimids =  (/ y_dimid, x_dimid /)
+
+  ! Define the variable. 
+  call handle_err(nf90_def_var(ncid, "data", NF90_INT, dimids, varid))
+
+  ! With classic model netCDF-4 file, enddef must be called.
+  call handle_err(nf90_enddef(ncid))
+
+  ! Determine what part of the variable will be written for this
+  ! processor. It's a checkerboard decomposition.
+  count = (/ NX / 2, NY / 2 /)
+  if (my_rank .eq. 0) then
+     start = (/ 1, 1 /)
+  else if (my_rank .eq. 1) then
+     start = (/ NX / 2 + 1, 1 /)
+  else if (my_rank .eq. 2) then
+     start = (/ 1, NY / 2 + 1 /)
+  else if (my_rank .eq. 3) then
+     start = (/ NX / 2 + 1, NY / 2 + 1 /)
+  endif
+
+  ! Write this processor's data.
+  call handle_err(nf90_put_var(ncid, varid, data_out, start = start, count = count))
+
+  ! Close the file. 
+  call handle_err(nf90_close(ncid))
+
+  ! Reopen the file.
+  call handle_err(nf90_open(FILE_NAME, IOR(nf90_nowrite, nf90_mpiio), ncid, &
+       comm = MPI_COMM_WORLD, info = MPI_INFO_NULL))
+  
+  ! Check some stuff out.
+  call handle_err(nf90_inquire(ncid, ndims, nvars, ngatts, unlimdimid, file_format))
+  if (ndims /= 2 .or. nvars /= 1 .or. ngatts /= 0 .or. unlimdimid /= -1 .or. &
+       file_format /= nf90_format_netcdf4_classic) stop 3
+
+  ! Set collective access on this variable. This will cause all
+  ! reads/writes to happen together on every processor. Fairly
+  ! pointless, in this contexct, but I want to at least call this
+  ! function once in my testing.
+  call handle_err(nf90_var_par_access(ncid, varid, nf90_collective))
+      
+  ! Read this processor's data.
+  call handle_err(nf90_get_var(ncid, varid, data_in, start = start, count = count))
+
+  ! Check the data.
+  do x = 1, NX / 2
+     do y = 1, NY / 2
+        if (data_in(y, x) .ne. my_rank) stop 4
+     end do
+  end do
+
+  ! Close the file. 
+  call handle_err(nf90_close(ncid))
+
+  call MPI_Finalize(ierr)
+
+  if (my_rank .eq. 0) print *,'*** SUCCESS!'
+
+contains
+!     This subroutine handles errors by printing an error message and
+!     exiting with a non-zero status.
+  subroutine handle_err(errcode)
+    use netcdf
+    implicit none
+    integer, intent(in) :: errcode
+    
+    if(errcode /= nf90_noerr) then
+       print *, 'Error: ', trim(nf90_strerror(errcode))
+       stop 2
+    endif
+  end subroutine handle_err
+end program f90tst_parallel

--- a/tools/maketests/f90tst_vars.f90
+++ b/tools/maketests/f90tst_vars.f90
@@ -1,0 +1,105 @@
+!     This is part of the netCDF package.
+!     Copyright 2006 University Corporation for Atmospheric Research/Unidata.
+!     See COPYRIGHT file for conditions of use.
+
+!     This program tests netCDF-4 variable functions from fortran.
+
+!     $Id: f90tst_vars.f90,v 1.8 2009/02/23 17:55:10 ed Exp $
+
+program f90tst_vars
+  use typeSizes
+  use netcdf
+  implicit none
+  
+  ! This is the name of the data file we will create.
+  character (len = *), parameter :: FILE_NAME = "f90tst_vars.nc"
+
+  ! We are writing 2D data, a 6 x 12 grid. 
+  integer, parameter :: MAX_DIMS = 2
+  integer, parameter :: NX = 6, NY = 12
+  integer :: data_out(NY, NX), data_in(NY, NX)
+
+  ! We need these ids and other gunk for netcdf.
+  integer :: ncid, varid, dimids(MAX_DIMS), chunksizes(MAX_DIMS), chunksizes_in(MAX_DIMS)
+  integer :: x_dimid, y_dimid, contig
+  integer :: mode_flag
+  integer :: nvars, ngatts, ndims, unlimdimid, file_format
+  integer :: x, y
+  integer :: CACHE_SIZE = 1000000;
+  ! integer, parameter :: CACHE_SIZE = 1000000
+
+  print *, ''
+  print *,'*** Testing definition of netCDF-4 vars from Fortran 90.'
+
+  ! Create some pretend data.
+  do x = 1, NX
+     do y = 1, NY
+        data_out(y, x) = (x - 1) * NY + (y - 1)
+     end do
+  end do
+
+  ! Create the netCDF file. 
+  mode_flag = IOR(nf90_netcdf4, nf90_classic_model) 
+  ! call handle_err(nf90_create(FILE_NAME, mode_flag, ncid, cache_size = CACHE_SIZE))
+  call handle_err(nf90_create(FILE_NAME, mode_flag, ncid, 0, CACHE_SIZE))
+
+  ! Define the dimensions.
+  call handle_err(nf90_def_dim(ncid, "x", NX, x_dimid))
+  call handle_err(nf90_def_dim(ncid, "y", NY, y_dimid))
+  dimids =  (/ y_dimid, x_dimid /)
+
+  ! Define the variable. 
+  call handle_err(nf90_def_var(ncid, "data", NF90_INT, dimids, varid))
+
+  ! Set up chunking.
+  chunksizes = (/ NY, NX /)
+  call handle_err(nf90_def_var_chunking(ncid, varid, 0, chunksizes))
+
+  ! With classic model netCDF-4 file, enddef must be called.
+  call handle_err(nf90_enddef(ncid))
+
+  ! Write the pretend data to the file.
+  call handle_err(nf90_put_var(ncid, varid, data_out))
+
+  ! Close the file. 
+  call handle_err(nf90_close(ncid))
+
+  ! Reopen the file.
+  call handle_err(nf90_open(FILE_NAME, nf90_nowrite, ncid))
+  
+  ! Check some stuff out.
+  call handle_err(nf90_inquire(ncid, ndims, nvars, ngatts, unlimdimid, file_format))
+  if (ndims /= 2 .or. nvars /= 1 .or. ngatts /= 0 .or. unlimdimid /= -1 .or. &
+       file_format /= nf90_format_netcdf4_classic) stop 2
+
+  call handle_err(nf90_inq_var_chunking(ncid, varid, contig, chunksizes_in))
+  if (chunksizes_in(1) /= chunksizes(1) .or. chunksizes_in(2) /= chunksizes(2)) &
+       stop 2
+
+  ! Check the data.
+  call handle_err(nf90_get_var(ncid, varid, data_in))
+  do x = 1, NX
+     do y = 1, NY
+        if (data_out(y, x) .ne. data_in(y, x)) stop 3
+     end do
+  end do
+
+  ! Close the file. 
+  call handle_err(nf90_close(ncid))
+
+  print *,'*** SUCCESS!'
+
+contains
+!     This subroutine handles errors by printing an error message and
+!     exiting with a non-zero status.
+  subroutine handle_err(errcode)
+    use netcdf
+    implicit none
+    integer, intent(in) :: errcode
+    
+    if(errcode /= nf90_noerr) then
+       print *, 'Error: ', trim(nf90_strerror(errcode))
+       stop 2
+    endif
+  end subroutine handle_err
+end program f90tst_vars

--- a/verification/testNF90io/README.rst
+++ b/verification/testNF90io/README.rst
@@ -1,0 +1,78 @@
+Example to test pkg/nf90io
+==========================
+
+This example tests ``pkg/nf90io`` and
+``pkg/diagnostics/diagnostics_nf90io_out.F``.
+
+Historically, netcdf output for the ``MITgcm`` has been via a
+non-parallel implimentation, and netcdf files were saved as
+one-per-tile, and pasted together afterwards with ``matlab`` or
+``python`` routines. These can fail for very large models since it
+requires large data sets to be loaded into memory.
+
+``pkg/nf90io`` impliments parallel saving, so just one ``netcdf`` file
+is saved for all the tiles.
+
+The output is controlled by the ``diagnostics`` package only. Setting
+``diag_nf90io=.TRUE.`` in ``data.diagnostics`` allows the single-file
+netcdf files to be saved. Note that we allow ``diag_mnc=.TRUE.`` to also
+be set if the user wants both (though the information should be
+duplicated). ``diag_nf90io=.TRUE.`` is set if ``NF90IO`` is found by
+``genmake2`` and ``useNF90io=.TRUE.`` in ``data.pkg``.
+
+One difference with other i/o in the MITgcm is that the file writes will
+*not* overwrite old files, but will append data to the end. This is done
+on purpose to allow files to be contiguously saved after a model restart
+using pickup files. If you want the file to be clobbered, you need to
+delete it manually. Note that if the model configuration changes in a
+way that incompatible with the old files ``NF90`` itself will throw an
+error.
+
+This example is a test of that functionality. It should make the files
+``statevars.nc``, ``statevars2d.nc`` and ``levelvars.nc`` in the
+\`./run/' directory.
+
+Compiling
+---------
+
+This test relies on having a parallel enabled version ``netcdf4``.
+Usually enabled when ``hdf5`` has been installed as parallel. Of course
+it also requires ``mpi``.
+
+``genmake2`` checks for ``nf90io`` by compiling a small test program. If
+this test fails then either your ``netcdf`` was not compiled with
+parallel libraries or you have not set your ``INCLUDES`` and ``LIBS``
+variables correctly in your build options file.
+
+My build\_options look like:
+
+::
+
+    CPP='/usr/local/bin/cpp-7 -traditional -P'
+    FC=mpif90
+    CC=mpicc
+    LINK=$FC
+    NOOPTFLAGS='-O0'
+    MAKEDEPEND='makedepend'
+    DEFINES='-DWORDLENGTH=4 -DALWAYS_USE_MPI -DALLOW_USE_MPI'
+    INCLUDES = '-I. /usr/local/include'
+    FFLAGS='-Wunused -Wuninitialized'
+    FOPTIM='-O3 -funroll-loops -ftree-vectorize -ffpe-trap=invalid'
+
+To build, make a ``build/`` directory. Run ``genmake2``. Run
+``make depend`` and then run ``make``.
+
+Setting up and running
+----------------------
+
+The file ``input/gendata.py`` should set up a directory ``run/`` where
+the model should be run. The initialization files will be put there. In
+order to run, something like:
+
+::
+
+    % mpirun -n 8 ./mitgcmuv
+
+The result should be three netcdf files ``statevars.nc``,
+``statevars2d.nc``, and ``levelvars.nc``, as specified in
+``input/data.diagnostics``.

--- a/verification/testNF90io/code/DIAGNOSTICS_SIZE.h
+++ b/verification/testNF90io/code/DIAGNOSTICS_SIZE.h
@@ -1,0 +1,32 @@
+C $Header$
+C $Name$
+
+
+C     Diagnostics Array Dimension
+C     ---------------------------
+C     ndiagMax   :: maximum total number of available diagnostics
+C     numlists   :: maximum number of diagnostics list (in data.diagnostics)
+C     numperlist :: maximum number of active diagnostics per list (data.diagnostics)
+C     numLevels  :: maximum number of levels to write    (data.diagnostics)
+C     numDiags   :: maximum size of the storage array for active 2D/3D diagnostics
+C     nRegions   :: maximum number of regions (statistics-diagnostics)
+C     sizRegMsk  :: maximum size of the regional-mask (statistics-diagnostics)
+C     nStats     :: maximum number of statistics (e.g.: aver,min,max ...)
+C     diagSt_size:: maximum size of the storage array for statistics-diagnostics
+C Note : may need to increase "numDiags" when using several 2D/3D diagnostics,
+C  and "diagSt_size" (statistics-diags) since values here are deliberately small.
+      INTEGER    ndiagMax
+      INTEGER    numlists, numperlist, numLevels
+      INTEGER    numDiags
+      INTEGER    nRegions, sizRegMsk, nStats
+      INTEGER    diagSt_size
+      PARAMETER( ndiagMax = 500 )
+      PARAMETER( numlists = 10, numperlist = 50, numLevels=2*Nr )
+      PARAMETER( numDiags = 10*Nr )
+      PARAMETER( nRegions = 0 , sizRegMsk = 1 , nStats = 4 )
+      PARAMETER( diagSt_size = 10*Nr )
+
+
+CEH3 ;;; Local Variables: ***
+CEH3 ;;; mode:fortran ***
+CEH3 ;;; End: ***

--- a/verification/testNF90io/code/SIZE.h
+++ b/verification/testNF90io/code/SIZE.h
@@ -1,0 +1,65 @@
+C $Header: /u/gcmpack/MITgcm/model/inc/SIZE.h,v 1.28 2009/05/17 21:15:07 jmc Exp $
+C $Name: checkpoint65f $
+
+C
+CBOP
+C    !ROUTINE: SIZE.h
+C    !INTERFACE:
+C    include SIZE.h
+C    !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SIZE.h Declare size of underlying computational grid.
+C     *==========================================================*
+C     | The design here support a three-dimensional model grid
+C     | with indices I,J and K. The three-dimensional domain
+C     | is comprised of nPx*nSx blocks of size sNx along one axis
+C     | nPy*nSy blocks of size sNy along another axis and one
+C     | block of size Nz along the final axis.
+C     | Blocks have overlap regions of size OLx and OLy along the
+C     | dimensions that are subdivided.
+C     *==========================================================*
+C     \ev
+CEOP
+C     Voodoo numbers controlling data layout.
+C     sNx :: No. X points in sub-grid.
+C     sNy :: No. Y points in sub-grid.
+C     OLx :: Overlap extent in X.
+C     OLy :: Overlat extent in Y.
+C     nSx :: No. sub-grids in X.
+C     nSy :: No. sub-grids in Y.
+C     nPx :: No. of processes to use in X.
+C     nPy :: No. of processes to use in Y.
+C     Nx  :: No. points in X for the total domain.
+C     Ny  :: No. points in Y for the total domain.
+C     Nr  :: No. points in Z for full process domain.
+      INTEGER sNx
+      INTEGER sNy
+      INTEGER OLx
+      INTEGER OLy
+      INTEGER nSx
+      INTEGER nSy
+      INTEGER nPx
+      INTEGER nPy
+      INTEGER Nx
+      INTEGER Ny
+      INTEGER Nr
+      PARAMETER (
+     &           sNx =  4,
+     &           sNy =   6,
+     &           OLx =   4,
+     &           OLy =   4,
+     &           nSx =   1,
+     &           nSy =   1,
+     &           nPx =   4,
+     &           nPy =   2,
+     &           Nx  = sNx*nSx*nPx,
+     &           Ny  = sNy*nSy*nPy,
+     &           Nr  =  6)
+
+C     MAX_OLX :: Set to the maximum overlap region size of any array
+C     MAX_OLY    that will be exchanged. Controls the sizing of exch
+C                routine buffers.
+      INTEGER MAX_OLX
+      INTEGER MAX_OLY
+      PARAMETER ( MAX_OLX = OLx,
+     &            MAX_OLY = OLy )

--- a/verification/testNF90io/code/packages.conf
+++ b/verification/testNF90io/code/packages.conf
@@ -1,0 +1,7 @@
+
+# $Header: /u/gcmpack/MITgcm/verification/internal_wave/code/packages.conf,v 1.4 2004/03/25 15:20:33 adcroft Exp $
+# $Name:  $
+
+gfd
+nf90io
+diagnostics

--- a/verification/testNF90io/input/checkit.py
+++ b/verification/testNF90io/input/checkit.py
@@ -1,0 +1,15 @@
+import numpy as np
+import xarray as xr
+
+data = xr.open_dataset('../run/statevars.nc')
+print('*****************')
+print('statevars.nc:\n\n')
+
+print(data)
+data.close()
+
+print('\n\n*****************')
+print('statevars2d.nc:\n\n')
+data = xr.open_dataset('../run/statevars2d.nc')
+print(data)
+data.close()

--- a/verification/testNF90io/input/data
+++ b/verification/testNF90io/input/data
@@ -1,0 +1,80 @@
+# ====================
+# | Model parameters |
+# ====================
+#
+# See src/ini_parms.F for possible parameters.
+#
+# Continuous equation parameters
+ &PARM01
+ debugLevel=2,
+ tRefFile='TRef.bin',
+ sRef= 6*35.,
+ viscAz=1.E-5,
+ viscAh=1.0E-4,
+ no_slip_sides=.FALSE.,
+ no_slip_bottom=.FALSE.,
+ viscA4=0.E12,
+ diffKhT=1.0E-4,
+ diffKzT=1.E-5,
+ diffKhS=1.E3,
+ diffKzS=1.E-5,
+ f0=0.E-4,
+ beta=0.02E-11,
+ tAlpha=2.E-4,
+ sBeta =0.E-4,
+ gravity=9.81,
+ gBaro=9.81,
+ rigidLid=.FALSE.,
+ implicitFreeSurface=.TRUE.,
+ eosType='LINEAR',
+ nonHydrostatic=.FALSE.,
+ readBinaryPrec=64,
+ saltStepping=.FALSE.,
+# minimum cell fraction.  This reduces steppiness..
+  hFacMin=0.1,
+  exactConserv=.FALSE.,
+  implicitDiffusion=.TRUE.
+  implicitViscosity=.TRUE.
+# Superbee on:
+ tempAdvScheme=77,
+ staggerTimeStep=.TRUE.,
+/
+
+# Elliptic solver parameters
+ &PARM02
+ cg2dMaxIters=1000,
+ cg2dTargetResidual=1.E-13,
+ cg3dMaxIters=400,
+ cg3dTargetResidual=1.E-13,
+/
+
+# Time stepping parameters
+ &PARM03
+# times are in s
+ startTime=0,
+ endTime=1860,
+ deltaT=12.4,
+ abEps=0.1,
+# once per tide checkpoint...
+ pChkptFreq=44640,
+ chkptFreq=0.0,
+ dumpFreq=0,
+ dumpInitAndLast=.FALSE.
+ monitorFreq=1860,
+/
+
+# Gridding parameters
+ &PARM04
+ usingCartesianGrid=.TRUE.,
+ usingSphericalPolarGrid=.FALSE.,
+ delXfile='delXvar.bin',
+ delYfile='delYvar.bin',
+ delRfile = 'delZvar.bin',
+/
+
+# Input datasets
+ &PARM05
+ bathyFile='topo.bin',
+ mdsioLocalDir='../../',
+ hydrogThetaFile='T0.bin',
+ /

--- a/verification/testNF90io/input/data.diagnostics
+++ b/verification/testNF90io/input/data.diagnostics
@@ -1,0 +1,32 @@
+# diagnostics Package
+
+&diagnostics_list 
+# 3D variables.
+ frequency(1)  = -124,
+ timePhase(1)      =  0,	
+ fields(1:6,1) = 'UVEL    ',
+ 	       	 'VVEL    ',
+		 'WVEL    ',
+		 'THETA   ',
+		 'SALT    ',
+		 'PHIHYD  ',
+ filename(1)   = 'statevars'
+#
+# 2D state vars.  Bummer these can't be in same file as above.
+ filename(2)   = 'statevars2d'
+ frequency(2)  = -124,
+ timePhase(2)  = 0,
+ fields(1:2,2) = 'ETAN    ',
+ 	         'PHIBOT  ',
+#
+# test level vars
+ filename(3)   = 'levelvars'
+ frequency(3)  = 124,
+ fields(1:2,3) = 'THETA   ',
+ 	       	 'SALT    ',
+ levels(1:3,3) = 1., 3., 6., 
+/
+
+
+&diag_statis_parms
+/

--- a/verification/testNF90io/input/data.pkg
+++ b/verification/testNF90io/input/data.pkg
@@ -1,0 +1,5 @@
+# Packages
+ &PACKAGES
+ useDIAGNOSTICS=.TRUE.,
+ useNF90IO=.TRUE.,
+ /

--- a/verification/testNF90io/input/eedata
+++ b/verification/testNF90io/input/eedata
@@ -1,0 +1,9 @@
+# Example "eedata" file
+# Lines beginning "#" are comments
+# nTx - No. threads per process in X
+# nTy - No. threads per process in Y
+ &EEPARMS
+ /
+# Note: Some systems use & as the
+# namelist terminator. Other systems
+# use a / character (as shown here).

--- a/verification/testNF90io/input/gendata.py
+++ b/verification/testNF90io/input/gendata.py
@@ -1,0 +1,90 @@
+import numpy as np
+import numpy.matlib as matlib
+import os
+import shutil
+
+H = 2000.
+h0=500.
+N0 = 5.2e-3
+
+outdir='../run/'
+try:
+  print('Making %s'%outdir)
+  os.mkdir(outdir)
+except:
+  print (outdir+' Exists')
+
+shutil.copy('./gendata.py',outdir)
+
+# These must match ../code/SIZE.h
+ny = 2*6
+nx = 4*4
+nz = 6
+
+
+dy = 1000.
+dx = 1000.
+
+dx = np.zeros(nx)+dx
+x=np.cumsum(dx)
+x = x-x[int(nx/2)]
+
+with open(outdir+"/delXvar.bin", "wb") as f:
+  dx.tofile(f)
+
+dy = np.zeros(ny) + dy
+y=np.cumsum(dy)
+
+with open(outdir+"/delYvar.bin", "wb") as f:
+  dy.tofile(f)
+f.close()
+
+# topo
+sigma = 4000. # m
+
+topo = 1500*np.exp(-x*x/(sigma**2))-1500+h0
+#topo = h0*exp(-x*x/(3000**2))
+topo[topo<0.]=0.
+topo=-H+topo
+topo[topo<-H]=-H
+
+TT0 = matlib.repmat(topo,1,ny)
+with open(outdir+"/topo.bin", "wb") as f:
+  TT0.tofile(f)
+f.close()
+# dz:
+# dz is from the surface down (right?).  Its saved as positive.
+
+dz=np.zeros(nz)+H/nz
+
+with open(outdir+"/delZvar.bin", "wb") as f:
+  dz.tofile(f)
+f.close()
+
+# temperature profile...
+g=9.8
+alpha = 2e-4
+T0 = 28+np.cumsum(N0**2/g/alpha*(-dz))
+
+with open(outdir+"/TRef.bin", "wb") as f:
+  T0.tofile(f)
+f.close()
+
+# save T0 over whole domain
+TT0 = matlib.repmat(T0,nx,ny).T
+with open(outdir+"/T0.bin", "wb") as f:
+  TT0.tofile(f)
+
+
+## Copy some other files
+shutil.copy('data', outdir+'/data')
+shutil.copy('eedata', outdir)
+shutil.copy('data.diagnostics', outdir)
+shutil.copy('data.pkg', outdir+'/data.pkg')
+# also store these.  They are small and helpful to document what we did
+for nm in {'input','code'}:
+  to_path = outdir+'/'+nm
+  if os.path.exists(to_path):
+    shutil.rmtree(to_path)
+    shutil.copytree('../'+nm, outdir+'/'+nm)
+shutil.copy('../build/mitgcmuv', outdir)


### PR DESCRIPTION
### Preface

Developers: First, feel free to ignore if you are not ready for "real" pull requests yet.  I thought at the worst case you could have a full pull request to look at.  I'm more than happy to resubmit this at a more appropriate time.  

### Description

This is a rudimentary implementation of the netcdf4 parallel writing, so that each tile in an mpi process writes to the same file, as described: https://www.unidata.ucar.edu/software/netcdf/netcdf-4/newdocs/netcdf-f90/

Currently it only supports writes using `pkg/diagnostics`.  Set ` diag_nf90io=.TRUE.` in `data.diagnostics`.

Modifies `genmake2` to test for NF90.  Also changes `.f.o:` Makefile directive to have `INCLUDES` as a flag for the compiler to accommodate `use netcdf` commands in the `*.f` files. 

See `verification/testNF90io/` for a basic example.  

See the README.rst in `pkg/nf90io` for a possible manual entry.  

### Todo:

- [ ] Add a test to `genmake2` that tests if hdf5 and netcdf have been compiled with parallel support:  This may be beyond my expertise.  I note that `autoconf` has such a test, and maybe their macro could be used.  
- [x] Write an appropriate test for automated testing: ditto the above.  I've tested this, but I'm not quite sure how one does parallel tests on Travis CI etc: See `verification/testNF90io`
- [x] Add to the documentation.  (Not sure I should do this now given the state of the new docs)
- [x] Come up with a way to extend to other packages.  How does `mnc` do the time alignment between the different packages.  
- [x] Redo the test case to use `diagnostics`
- [x] Remove some debugging `print` statements.
- [x] Remove or add flag to toggle the statevar dump.  Probably just add a flag and have it default to `.FALSE.`